### PR TITLE
2015 Day 8 Solution

### DIFF
--- a/AdventOfCode2015/Problems/Day8.cs
+++ b/AdventOfCode2015/Problems/Day8.cs
@@ -9,6 +9,7 @@ namespace AdventOfCode2015.Problems
         int _firstResult = 0;
         int _secondResult = 0;
         string[] _digitalList = [];
+        int _stringLiteralLength = 0;
         #endregion
 
         #region Properties
@@ -68,62 +69,60 @@ namespace AdventOfCode2015.Problems
 
         public override T SolveFirstProblem<T>()
         {
-            var stringLiteralLength = 0;
+            _stringLiteralLength = 0;
             var stringInMemoryLength = 0;
 
             var hexRegex = HexadecimalRegex();
             var quoteRegex = EscapedQuoteRegex();
             var backslashRegex = EscapedBackslashRegex();
-            var hexValues = new List<string>();
-            //foreach (var input in _digitalList)
-            //{
-            //    stringLiteralLength += input.Length;
-            //    var inMemoryLength = input.Length - 2;
-
-            //    var quoteMatches = quoteRegex.Matches(input);
-            //    var backslashMatches = backslashRegex.Matches(input);
-
-            //    // since \" and \\ equals 2 -> 1 we can just count the matches and remove these from the inMemoryLength
-            //    inMemoryLength -= quoteMatches.Count();
-            //    inMemoryLength -= backslashMatches.Count();
-
-            //    // hex matches are 4 chars -> 1 so we do count * 4-1 (3)
-            //    var hexCharCount = hexMatches.Count() * 3;
-            //    inMemoryLength -= hexCharCount;
-
-            //    stringInMemoryLength += inMemoryLength;
-            //}
 
             foreach (var input in _digitalList)
             {
                 var inputCopy = input;
-                stringLiteralLength += inputCopy.Length;
+                _stringLiteralLength += inputCopy.Length;
 
+                inputCopy = backslashRegex.Replace(inputCopy, "#");
                 inputCopy = hexRegex.Replace(inputCopy, "#");
                 inputCopy = quoteRegex.Replace(inputCopy, "#");
-                inputCopy = backslashRegex.Replace(inputCopy, "#");
                 var inMemoryLength = inputCopy.Length - 2;
 
                 stringInMemoryLength += inMemoryLength;
-
-
-                var hexMatches = hexRegex.Matches(input);
-
-                foreach (Match match in hexMatches)
-                    hexValues.Add(ConvertHex(match.Value.Substring(2)));
             }
 
-            var result = stringLiteralLength - stringInMemoryLength;
+            var result = _stringLiteralLength - stringInMemoryLength;
             return (T)Convert.ChangeType(result, typeof(T));
-            
-            //1375 WRONG TOO HIGH
-            //1362 WRONG N/A
-            //1330 WRONG TOO LOW
-            // 1328
         }
         public override T SolveSecondProblem<T>()
         {
-            return (T)Convert.ChangeType(0, typeof(T));
+
+            var cumulativeEncodedStringLength = 0;
+            var backslashRegex = BackslashRegex();
+            var quoteRegex = QuoteRegex();
+            foreach (var input in _digitalList)
+            {
+                var encodedStringLength = 0;
+                var inputCopy = input;
+                var backslashMatches = backslashRegex.Matches(inputCopy);
+                var quoteMatches = quoteRegex.Matches(inputCopy);
+                foreach (Match match in backslashMatches) 
+                {
+                    encodedStringLength += 2;
+                }
+                foreach (Match match in quoteMatches)
+                {
+                    encodedStringLength += 2;
+                }
+
+                inputCopy = backslashRegex.Replace(inputCopy, @"");
+                inputCopy = quoteRegex.Replace(inputCopy, "");
+                encodedStringLength += inputCopy.Length + 2; //Add start + end changes -> "" -> "\"\""
+
+                cumulativeEncodedStringLength += encodedStringLength;
+            }
+
+
+            var result = cumulativeEncodedStringLength - _stringLiteralLength;
+            return (T)Convert.ChangeType(result, typeof(T));
         }
 
         public override void OutputSolution()
@@ -145,29 +144,17 @@ namespace AdventOfCode2015.Problems
         [GeneratedRegex(@"\\\\")]
         private static partial Regex EscapedBackslashRegex();
 
-        public static string ConvertHex(string hexString)
-        {
-            try
-            {
-                string ascii = string.Empty;
 
-                for (int i = 0; i < hexString.Length; i += 2)
-                {
-                    string hs = string.Empty;
+        //
+        [GeneratedRegex(@"\\")]
+        private static partial Regex BackslashRegex();
 
-                    hs = hexString.Substring(i, 2);
-                    uint decval = System.Convert.ToUInt32(hs, 16);
-                    char character = System.Convert.ToChar(decval);
-                    ascii += character;
+        //
+        [GeneratedRegex(@"(?<!\\)\\x")]
+        private static partial Regex BackslashHexadecimalRegex();
 
-                }
-
-                return ascii;
-            }
-            catch (Exception ex) { Console.WriteLine(ex.Message); }
-
-            return string.Empty;
-        }
+        [GeneratedRegex(@"[""]")]
+        private static partial Regex QuoteRegex();
 
         #endregion
     }

--- a/AdventOfCode2015/Problems/Day8.cs
+++ b/AdventOfCode2015/Problems/Day8.cs
@@ -150,9 +150,6 @@ namespace AdventOfCode2015.Problems
         private static partial Regex BackslashRegex();
 
         //
-        [GeneratedRegex(@"(?<!\\)\\x")]
-        private static partial Regex BackslashHexadecimalRegex();
-
         [GeneratedRegex(@"[""]")]
         private static partial Regex QuoteRegex();
 

--- a/AdventOfCode2015/Problems/Day8.cs
+++ b/AdventOfCode2015/Problems/Day8.cs
@@ -1,17 +1,14 @@
-﻿namespace AdventOfCode2015.Problems
+﻿using System.Text.RegularExpressions;
+
+namespace AdventOfCode2015.Problems
 {
-    public class Day8 : DayBase
+    public partial class Day8 : DayBase
     {
-
-
         #region Fields
         string _inputPath = string.Empty;
         int _firstResult = 0;
         int _secondResult = 0;
-        int _sum = 0;
-        string[] _antennaSignals = [];
-        char[] _antennaFrequencies = [];
-        List<(int row, int col)> _antinodes = new List<(int, int)>();
+        string[] _digitalList = [];
         #endregion
 
         #region Properties
@@ -50,54 +47,6 @@
             }
         }
 
-        int Sum
-        {
-            get => _sum;
-            set
-            {
-                if (_sum != value)
-                {
-                    _sum = value;
-                }
-            }
-        }
-        string[] AntennaSignals
-        {
-            get => _antennaSignals;
-            set
-            {
-                if (_antennaSignals != value)
-                {
-                    _antennaSignals = value;
-                }
-            }
-        }
-
-        char[] AntennaFrequencies
-        {
-            get => _antennaFrequencies;
-            set
-            {
-                if (_antennaFrequencies != value)
-                {
-                    _antennaFrequencies = value;
-                }
-            }
-        }
-
-        List<(int row, int col)> Antinodes
-        {
-            get => _antinodes;
-            set
-            {
-                if (_antinodes != value)
-                {
-                    _antinodes = value;
-                }
-            }
-        }
-
-
         #endregion
 
         #region Constructor
@@ -114,20 +63,67 @@
         #region Methods
         public override void InitialiseProblem()
         {
-            AntennaSignals = File.ReadLines(_inputPath).ToArray();
-            AntennaFrequencies = string.Join(Environment.NewLine, AntennaSignals).Select(x => x).Where(x => x != '\r' && x != '\n' && x != '.').Distinct().ToArray();
+            _digitalList = File.ReadAllLines(_inputPath);
         }
 
         public override T SolveFirstProblem<T>()
         {
-            Sum = CreateFrequencyPositions(false);
+            var stringLiteralLength = 0;
+            var stringInMemoryLength = 0;
 
-            return (T)Convert.ChangeType(Sum, typeof(T));
+            var hexRegex = HexadecimalRegex();
+            var quoteRegex = EscapedQuoteRegex();
+            var backslashRegex = EscapedBackslashRegex();
+            var hexValues = new List<string>();
+            //foreach (var input in _digitalList)
+            //{
+            //    stringLiteralLength += input.Length;
+            //    var inMemoryLength = input.Length - 2;
+
+            //    var quoteMatches = quoteRegex.Matches(input);
+            //    var backslashMatches = backslashRegex.Matches(input);
+
+            //    // since \" and \\ equals 2 -> 1 we can just count the matches and remove these from the inMemoryLength
+            //    inMemoryLength -= quoteMatches.Count();
+            //    inMemoryLength -= backslashMatches.Count();
+
+            //    // hex matches are 4 chars -> 1 so we do count * 4-1 (3)
+            //    var hexCharCount = hexMatches.Count() * 3;
+            //    inMemoryLength -= hexCharCount;
+
+            //    stringInMemoryLength += inMemoryLength;
+            //}
+
+            foreach (var input in _digitalList)
+            {
+                var inputCopy = input;
+                stringLiteralLength += inputCopy.Length;
+
+                inputCopy = hexRegex.Replace(inputCopy, "#");
+                inputCopy = quoteRegex.Replace(inputCopy, "#");
+                inputCopy = backslashRegex.Replace(inputCopy, "#");
+                var inMemoryLength = inputCopy.Length - 2;
+
+                stringInMemoryLength += inMemoryLength;
+
+
+                var hexMatches = hexRegex.Matches(input);
+
+                foreach (Match match in hexMatches)
+                    hexValues.Add(ConvertHex(match.Value.Substring(2)));
+            }
+
+            var result = stringLiteralLength - stringInMemoryLength;
+            return (T)Convert.ChangeType(result, typeof(T));
+            
+            //1375 WRONG TOO HIGH
+            //1362 WRONG N/A
+            //1330 WRONG TOO LOW
+            // 1328
         }
         public override T SolveSecondProblem<T>()
         {
-            Sum = CreateFrequencyPositions(true);
-            return (T)Convert.ChangeType(Sum, typeof(T));
+            return (T)Convert.ChangeType(0, typeof(T));
         }
 
         public override void OutputSolution()
@@ -136,58 +132,41 @@
             Console.WriteLine($"Second Solution is: {SecondResult}");
         }
 
-        private int CreateFrequencyPositions(bool isPartTwo)
+
+        //https://regex101.com/r/N3j4k1/4
+        [GeneratedRegex(@"(?<!\\)\\x[a-z0-9]{2}")]
+        private static partial Regex HexadecimalRegex();
+
+        //https://regex101.com/r/kkS2ue/2
+        [GeneratedRegex(@"\\[`""`](?!$)")]
+        private static partial Regex EscapedQuoteRegex();
+
+        //https://regex101.com/r/8tTh9g/2
+        [GeneratedRegex(@"\\\\")]
+        private static partial Regex EscapedBackslashRegex();
+
+        public static string ConvertHex(string hexString)
         {
-            Antinodes = new List<(int row, int col)>();
-            foreach (var frequency in AntennaFrequencies)
+            try
             {
-                var frequencyPositions = new List<(int, int)>();
-                var filteredAntennaSignals = AntennaSignals.ToArray();
-                for (int i = 0; i <= filteredAntennaSignals.Length - 1; i++)
+                string ascii = string.Empty;
+
+                for (int i = 0; i < hexString.Length; i += 2)
                 {
-                    for (int j = 0; j < filteredAntennaSignals[0].Length - 1; j++)
-                    {
-                        if (filteredAntennaSignals[i][j] == frequency)
-                        {
-                            frequencyPositions.Add((i, j));
-                        }
-                    }
+                    string hs = string.Empty;
+
+                    hs = hexString.Substring(i, 2);
+                    uint decval = System.Convert.ToUInt32(hs, 16);
+                    char character = System.Convert.ToChar(decval);
+                    ascii += character;
+
                 }
 
-                ProcessSignal(frequencyPositions, isPartTwo);
-
+                return ascii;
             }
-            Antinodes = Antinodes.Distinct().ToList();
-            return Antinodes.Count;
-        }
+            catch (Exception ex) { Console.WriteLine(ex.Message); }
 
-        void ProcessSignal(List<(int, int)> frequencyPositions, bool isPartTwo)
-        {
-            foreach ((int row, int col) frequencyPosition in frequencyPositions)
-            {
-                var otherFrequencyPositions = frequencyPositions.Where(x => x != frequencyPosition).ToList();
-                foreach ((int row, int col) otherFrequencyPosition in otherFrequencyPositions)
-                {
-                    (int row, int col) distance = (frequencyPosition.row - otherFrequencyPosition.row, frequencyPosition.col - otherFrequencyPosition.col);
-                    (int row, int col) antinode = (frequencyPosition.row + distance.row, frequencyPosition.col + distance.col);
-                    if (isPartTwo)
-                    {
-                        Antinodes.Add(frequencyPosition);
-                        while (antinode.row >= 0 && antinode.row <= AntennaSignals.Length - 1 && antinode.col >= 0 && antinode.col <= AntennaSignals[0].Length - 1)
-                        {
-                            Antinodes.Add(antinode);
-                            antinode = (antinode.row + distance.row, antinode.col + distance.col);
-                        }
-                    }
-                    else
-                    {
-                        if (antinode.row < 0 || antinode.row > AntennaSignals.Length - 1 || antinode.col < 0 || antinode.col > AntennaSignals[0].Length - 1)
-                            continue;
-                        else
-                            Antinodes.Add(antinode);
-                    }
-                }
-            }
+            return string.Empty;
         }
 
         #endregion

--- a/AdventOfCode2015Tests/AdventOfCode2015Tests.csproj
+++ b/AdventOfCode2015Tests/AdventOfCode2015Tests.csproj
@@ -264,6 +264,30 @@
     <None Update="Inputs\Day8\Day8Test3.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Inputs\Day8\Day8Test12.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day8\Day8Test11.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day8\Day8Test10.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day8\Day8Test9.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day8\Day8Test8.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day8\Day8Test7.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day8\Day8Test6.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day8\Day8Test5.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Inputs\Day8\Day8Test4.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/AdventOfCode2015Tests/Day7.cs
+++ b/AdventOfCode2015Tests/Day7.cs
@@ -3,6 +3,7 @@ namespace AdventOfCode2015Tests
     [TestClass]
     public class Day7
     {
+        //No day 7 Part 2 tests as it builds off the same logic covered in Part 1's tests
         [TestMethod]
         [DeploymentItem("Inputs/Day7/Day7Test1.txt")]
         public void Part1_FindsDValue_IsTrue()
@@ -59,13 +60,5 @@ namespace AdventOfCode2015Tests
             var instance = new AdventOfCode2015.Problems.Day7("Day7Test1.txt", "y");
             instance.FirstResult.Should().Be(456);
         }
-
-        //[TestMethod]
-        //[DeploymentItem("Inputs/Day7/Day7Test1.txt")]
-        //public void Part2_ProducesCorrectCalibrationResultTotal_IsTrue()
-        //{
-        //    var instance = new AdventOfCode2015.Problems.Day7("Day7Test1.txt");
-        //    instance.SecondResult.Should().Be(11387);
-        //}
     }
 }

--- a/AdventOfCode2015Tests/Day8.cs
+++ b/AdventOfCode2015Tests/Day8.cs
@@ -90,20 +90,92 @@ namespace AdventOfCode2015Tests
             instance.FirstResult.Should().Be(4);
         }
 
-        //[TestMethod]
-        //[DeploymentItem("Inputs/Day8/Day8Test1.txt")]
-        //public void Part2_ProducesCorrectTotalOfUniqueAntinodesFile1_IsTrue()
-        //{
-        //    var instance = new AdventOfCode2015.Problems.Day8("Day8Test1.txt");
-        //    instance.SecondResult.Should().Be(34);
-        //}
 
-        //[TestMethod]
-        //[DeploymentItem("Inputs/Day8/Day8Test4.txt")]
-        //public void Part2_ProducesCorrectTotalOfUniqueAntinodesFile4_IsTrue()
-        //{
-        //    var instance = new AdventOfCode2015.Problems.Day8("Day8Test4.txt");
-        //    instance.SecondResult.Should().Be(9);
-        //}
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test1.txt")]
+        public void Part2_ProducesCorrectResultFile1_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test1.txt");
+            instance.SecondResult.Should().Be(4);
+        }
+
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test2.txt")]
+        public void Part2_ProducesCorrectResultFile2_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test2.txt");
+            instance.SecondResult.Should().Be(4);
+        }
+
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test3.txt")]
+        public void Part2_ProducesCorrectResultFile3_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test3.txt");
+            instance.SecondResult.Should().Be(6);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test4.txt")]
+        public void Part2_ProducesCorrectResultFile4_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test4.txt");
+            instance.SecondResult.Should().Be(5);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test5.txt")]
+        public void Part2_ProducesCorrectResultFile5_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test5.txt");
+            instance.SecondResult.Should().Be(19);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test6.txt")]
+        public void Part2_ProducesCorrectResultFile6_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test6.txt");
+            instance.SecondResult.Should().Be(6);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test7.txt")]
+        public void Part2_ProducesCorrectResultFile7_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test7.txt");
+            instance.SecondResult.Should().Be(6);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test8.txt")]
+        public void Part2_ProducesCorrectResultFile8_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test8.txt");
+            instance.SecondResult.Should().Be(6);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test9.txt")]
+        public void Part2_ProducesCorrectResultFile9_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test9.txt");
+            instance.SecondResult.Should().Be(5);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test10.txt")]
+        public void Part2_ProducesCorrectResultFile10_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test10.txt");
+            instance.SecondResult.Should().Be(6);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test11.txt")]
+        public void Part2_ProducesCorrectResultFile11_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test11.txt");
+            instance.SecondResult.Should().Be(7);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test12.txt")]
+        public void Part2_ProducesCorrectResultFile12_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test12.txt");
+            instance.SecondResult.Should().Be(8);
+        }
     }
 }

--- a/AdventOfCode2015Tests/Day8.cs
+++ b/AdventOfCode2015Tests/Day8.cs
@@ -5,15 +5,15 @@ namespace AdventOfCode2015Tests
     {
         [TestMethod]
         [DeploymentItem("Inputs/Day8/Day8Test1.txt")]
-        public void Part1_ProducesCorrectTotalOfUniqueAntinodesFile1_IsTrue()
+        public void Part1_ProducesCorrectResultFile1_IsTrue()
         {
             var instance = new AdventOfCode2015.Problems.Day8("Day8Test1.txt");
-            instance.FirstResult.Should().Be(14);
+            instance.FirstResult.Should().Be(2);
         }
 
         [TestMethod]
         [DeploymentItem("Inputs/Day8/Day8Test2.txt")]
-        public void Part1_ProducesCorrectTotalOfUniqueAntinodesFile2_IsTrue()
+        public void Part1_ProducesCorrectResultFile2_IsTrue()
         {
             var instance = new AdventOfCode2015.Problems.Day8("Day8Test2.txt");
             instance.FirstResult.Should().Be(2);
@@ -21,26 +21,89 @@ namespace AdventOfCode2015Tests
 
         [TestMethod]
         [DeploymentItem("Inputs/Day8/Day8Test3.txt")]
-        public void Part1_ProducesCorrectTotalOfUniqueAntinodesFile3_IsTrue()
+        public void Part1_ProducesCorrectResultFile3_IsTrue()
         {
             var instance = new AdventOfCode2015.Problems.Day8("Day8Test3.txt");
+            instance.FirstResult.Should().Be(3);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test4.txt")]
+        public void Part1_ProducesCorrectResultFile4_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test4.txt");
+            instance.FirstResult.Should().Be(5);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test5.txt")]
+        public void Part1_ProducesCorrectResultFile5_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test5.txt");
+            instance.FirstResult.Should().Be(12);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test6.txt")]
+        public void Part1_ProducesCorrectResultFile6_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test6.txt");
+            instance.FirstResult.Should().Be(3);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test7.txt")]
+        public void Part1_ProducesCorrectResultFile7_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test7.txt");
+            instance.FirstResult.Should().Be(3);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test8.txt")]
+        public void Part1_ProducesCorrectResultFile8_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test8.txt");
+            instance.FirstResult.Should().Be(3);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test9.txt")]
+        public void Part1_ProducesCorrectResultFile9_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test9.txt");
+            instance.FirstResult.Should().Be(5);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test10.txt")]
+        public void Part1_ProducesCorrectResultFile10_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test10.txt");
+            instance.FirstResult.Should().Be(3);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test11.txt")]
+        public void Part1_ProducesCorrectResultFile11_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test11.txt");
+            instance.FirstResult.Should().Be(6);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day8/Day8Test12.txt")]
+        public void Part1_ProducesCorrectResultFile12_IsTrue()
+        {
+            var instance = new AdventOfCode2015.Problems.Day8("Day8Test12.txt");
             instance.FirstResult.Should().Be(4);
         }
 
-        [TestMethod]
-        [DeploymentItem("Inputs/Day8/Day8Test1.txt")]
-        public void Part2_ProducesCorrectTotalOfUniqueAntinodesFile1_IsTrue()
-        {
-            var instance = new AdventOfCode2015.Problems.Day8("Day8Test1.txt");
-            instance.SecondResult.Should().Be(34);
-        }
+        //[TestMethod]
+        //[DeploymentItem("Inputs/Day8/Day8Test1.txt")]
+        //public void Part2_ProducesCorrectTotalOfUniqueAntinodesFile1_IsTrue()
+        //{
+        //    var instance = new AdventOfCode2015.Problems.Day8("Day8Test1.txt");
+        //    instance.SecondResult.Should().Be(34);
+        //}
 
-        [TestMethod]
-        [DeploymentItem("Inputs/Day8/Day8Test4.txt")]
-        public void Part2_ProducesCorrectTotalOfUniqueAntinodesFile4_IsTrue()
-        {
-            var instance = new AdventOfCode2015.Problems.Day8("Day8Test4.txt");
-            instance.SecondResult.Should().Be(9);
-        }
+        //[TestMethod]
+        //[DeploymentItem("Inputs/Day8/Day8Test4.txt")]
+        //public void Part2_ProducesCorrectTotalOfUniqueAntinodesFile4_IsTrue()
+        //{
+        //    var instance = new AdventOfCode2015.Problems.Day8("Day8Test4.txt");
+        //    instance.SecondResult.Should().Be(9);
+        //}
     }
 }


### PR DESCRIPTION
Part 1 solution uses regex replace encoded values with a '#' since we know each encoded char goes to 1 character. We then cumulate each string value's length after replacing the encoded values - 2 which represents the extra "" at the beginning and end.

Part 2 is much simpler, although took a while to figure out, we only match on " and \ and foreach match we add 2 to the cumulative counter. We then replace these values in the string with nothing.

Leading to our calculation of x + y + 2 where x is all regex matches cumulated and y is the leftover string length. We add 2 to represent the additional speech marks at the beginning and end