### PR TITLE
Implemented Day 22 2015

### DIFF
--- a/AdventOfCode2015/CommonInternalTypes/Classes/Armor.cs
+++ b/AdventOfCode2015/CommonInternalTypes/Classes/Armor.cs
@@ -1,0 +1,16 @@
+﻿using AdventOfCode2015.CommonInternalTypes.Interfaces;
+
+namespace AdventOfCode2015.CommonInternalTypes.Classes
+{
+    internal class Armor : Wearable, IDefense
+    {
+        public int Defense { get; init; }
+
+        public Armor(string name, int cost, int defense)
+        {
+            Name = name;
+            Cost = cost;
+            Defense = defense;
+        }
+    }
+}

--- a/AdventOfCode2015/CommonInternalTypes/Classes/Boss.cs
+++ b/AdventOfCode2015/CommonInternalTypes/Classes/Boss.cs
@@ -1,0 +1,20 @@
+﻿namespace AdventOfCode2015.CommonInternalTypes.Classes
+{
+    internal class Boss : Character
+    {
+        public int EffectTimer { get; set; }
+        public Boss(int hitPoints, int damage, int defense)
+        {
+            HitPoints = hitPoints;
+            Damage = damage;
+            Defense = defense;
+        }
+
+        public Boss()
+        {
+            HitPoints = 0;
+            Damage = 0;
+            Defense = 0;
+        }
+    }
+}

--- a/AdventOfCode2015/CommonInternalTypes/Classes/Character.cs
+++ b/AdventOfCode2015/CommonInternalTypes/Classes/Character.cs
@@ -1,0 +1,10 @@
+﻿namespace AdventOfCode2015.CommonInternalTypes.Classes
+{
+    internal abstract class Character
+    {
+        public int HitPoints { get; set; }
+        public int Damage { get; set; }
+        public int Defense { get; set; }
+        public int Mana { get; set; }
+    }
+}

--- a/AdventOfCode2015/CommonInternalTypes/Classes/Player.cs
+++ b/AdventOfCode2015/CommonInternalTypes/Classes/Player.cs
@@ -1,0 +1,101 @@
+﻿namespace AdventOfCode2015.CommonInternalTypes.Classes
+{
+    internal class Player : Character
+    {
+        Weapon _weapon;
+        Armor? _armor;
+        List<Ring> _rings;
+
+        public Weapon Weapon
+        {
+            get => _weapon;
+            set
+            {
+                if (_weapon != value)
+                {
+                    _weapon = value;
+                    GetDamage();
+                }
+            }
+        }
+        public Armor? Armor
+        {
+            get => _armor;
+            set
+            {
+                if (_armor != value)
+                {
+                    _armor = value;
+                    GetDefense();
+                }
+            }
+        }
+        public List<Ring> Rings
+        {
+            get => _rings;
+            set
+            {
+                if (_rings != value)
+                {
+                    _rings = value;
+                    if (_rings.Count > 0)
+                    {
+                        GetDamage();
+                        GetDefense();
+                    }
+                }
+            }
+        }
+
+
+        public Player(int hitPoints, int damage, int defense)
+        {
+            HitPoints = hitPoints;
+            Damage = damage;
+            Defense = defense;
+            Rings = new();
+        }
+
+        public Player(int hitPoints, int mana)
+        {
+            HitPoints= hitPoints;
+            Mana = mana;
+        }
+
+        public int GetCost()
+        {
+            var cost = Weapon.Cost;
+            if (Armor != null)
+            {
+                cost += Armor.Cost;
+            }
+
+            cost += Rings.Select(x => x.Cost).Sum();
+
+            return cost;
+        }
+
+        public void GetDamage()
+        {
+            Damage = Weapon.Damage + Rings.Select(x => x.Damage).Sum();
+        }
+
+        public void GetDefense()
+        {
+            var armorDefense = 0;
+            if (Armor != null)
+                armorDefense = Armor.Defense;
+            Defense = armorDefense + Rings.Select(x => x.Defense).Sum();
+        }
+
+        public void ChangeGear(Weapon weapon, Armor armor, List<Ring> rings)
+        {
+            Weapon = weapon;
+            Armor = armor;
+            Rings = rings;
+
+            GetDamage();
+            GetDefense();
+        }
+    }
+}

--- a/AdventOfCode2015/CommonInternalTypes/Classes/Player.cs
+++ b/AdventOfCode2015/CommonInternalTypes/Classes/Player.cs
@@ -5,6 +5,9 @@
         Weapon _weapon;
         Armor? _armor;
         List<Ring> _rings;
+        int _defenseTimer { get; set; }
+        int _rechargeTimer { get; set; }
+
 
         public Weapon Weapon
         {
@@ -46,7 +49,28 @@
                 }
             }
         }
-
+        public int DefenseTimer
+        {
+            get => _defenseTimer;
+            set
+            {
+                if (_defenseTimer != value)
+                {
+                    _defenseTimer = value;
+                }
+            }
+        }
+        public int RechargeTimer
+        {
+            get => _rechargeTimer;
+            set
+            {
+                if (_rechargeTimer != value)
+                {
+                    _rechargeTimer = value;
+                }
+            }
+        }
 
         public Player(int hitPoints, int damage, int defense)
         {

--- a/AdventOfCode2015/CommonInternalTypes/Classes/Ring.cs
+++ b/AdventOfCode2015/CommonInternalTypes/Classes/Ring.cs
@@ -1,0 +1,19 @@
+﻿using AdventOfCode2015.CommonInternalTypes.Interfaces;
+
+namespace AdventOfCode2015.CommonInternalTypes.Classes
+{
+
+    internal class Ring : Wearable, IDamage, IDefense
+    {
+        public int Defense { get; init; }
+        public int Damage { get; init; }
+
+        public Ring(string name, int cost, int damage, int defense)
+        {
+            Name = name;
+            Cost = cost;
+            Damage = damage;
+            Defense = defense;
+        }
+    }
+}

--- a/AdventOfCode2015/CommonInternalTypes/Classes/Spell.cs
+++ b/AdventOfCode2015/CommonInternalTypes/Classes/Spell.cs
@@ -1,0 +1,26 @@
+﻿using AdventOfCode2015.CommonInternalTypes.Interfaces;
+
+namespace AdventOfCode2015.CommonInternalTypes.Classes
+{
+    internal class Spell : IDamage, IDefense
+    {
+        public string Name { get; set; }
+        public int ManaCost { get; set; }
+        public int Defense { get; init; }
+        public int Damage { get; init; }
+        public int Heal { get; init; }
+        public int ManaReturn { get; init; }
+        public int EffectTimer { get; init; }
+
+        public Spell(string name, int manaCost, int damage, int defense, int heal, int manaReturn, int effectTimer)
+        {
+            Name = name;
+            ManaCost = manaCost;
+            Damage = damage;
+            Defense = defense;
+            Heal = heal;
+            ManaReturn = manaReturn;
+            EffectTimer = effectTimer;
+        }
+    }
+}

--- a/AdventOfCode2015/CommonInternalTypes/Classes/Weapon.cs
+++ b/AdventOfCode2015/CommonInternalTypes/Classes/Weapon.cs
@@ -1,0 +1,16 @@
+﻿using AdventOfCode2015.CommonInternalTypes.Interfaces;
+
+namespace AdventOfCode2015.CommonInternalTypes.Classes
+{
+    internal class Weapon : Wearable, IDamage
+    {
+        public int Damage { get; init; }
+
+        public Weapon(string name, int cost, int damage)
+        {
+            Name = name;
+            Cost = cost;
+            Damage = damage;
+        }
+    }
+}

--- a/AdventOfCode2015/CommonInternalTypes/Classes/Wearable.cs
+++ b/AdventOfCode2015/CommonInternalTypes/Classes/Wearable.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AdventOfCode2015.CommonInternalTypes.Classes
+{
+    internal abstract class Wearable
+    {
+        public string Name { get; init; }
+        public int Cost { get; init; }
+    }
+}

--- a/AdventOfCode2015/CommonInternalTypes/Interfaces/IDamage.cs
+++ b/AdventOfCode2015/CommonInternalTypes/Interfaces/IDamage.cs
@@ -1,0 +1,7 @@
+﻿namespace AdventOfCode2015.CommonInternalTypes.Interfaces
+{
+    internal interface IDamage
+    {
+        int Damage { get; init; }
+    }
+}

--- a/AdventOfCode2015/CommonInternalTypes/Interfaces/IDefense.cs
+++ b/AdventOfCode2015/CommonInternalTypes/Interfaces/IDefense.cs
@@ -1,0 +1,7 @@
+﻿namespace AdventOfCode2015.CommonInternalTypes.Interfaces
+{
+    internal interface IDefense
+    {
+        int Defense { get; init; }
+    }
+}

--- a/AdventOfCode2015/Problems/Day21.cs
+++ b/AdventOfCode2015/Problems/Day21.cs
@@ -1,6 +1,6 @@
-﻿using CommonTypes.CommonTypes.HelperFunctions;
+﻿using AdventOfCode2015.CommonInternalTypes.Classes;
+using CommonTypes.CommonTypes.HelperFunctions;
 using CommonTypes.CommonTypes.Regex;
-using System.Text.RegularExpressions;
 
 namespace AdventOfCode2015.Problems
 {
@@ -14,7 +14,7 @@ namespace AdventOfCode2015.Problems
         List<Weapon> _weapons = new List<Weapon>();
         List<Armor> _armors = new List<Armor>();
         List<Ring> _rings = new List<Ring>();
-        Boss _boss = null;
+        Boss _boss = new();
         Player _player = new Player(100, 0, 0);
 
         Dictionary<(Weapon weapon, Armor? armor, List<Ring>), (int cost, bool success)> _bossAttempts = new();
@@ -179,166 +179,9 @@ namespace AdventOfCode2015.Problems
         }
 
         #region Internal Classes
-        internal interface IDamage
-        {
-            int Damage { get; init; }
-        }
-        internal interface IDefense
-        {
-            int Defense { get; init; }
-        }
 
-        internal abstract class Wearable
-        {
-            public string Name { get; init; }
-            public int Cost { get; init; }
-        }
+       
 
-        internal class Weapon : Wearable, IDamage
-        {
-            public int Damage { get; init; }
-
-            public Weapon(string name, int cost, int damage)
-            {
-                Name = name;
-                Cost = cost;
-                Damage = damage;
-            }
-        }
-        internal class Armor : Wearable, IDefense
-        {
-            public int Defense { get; init; }
-
-            public Armor(string name, int cost, int defense)
-            {
-                Name = name;
-                Cost = cost;
-                Defense = defense;
-            }
-        }
-        internal class Ring : Wearable, IDamage, IDefense
-        {
-            public int Defense { get; init; }
-            public int Damage { get; init; }
-
-            public Ring(string name, int cost, int damage, int defense)
-            {
-                Name = name;
-                Cost = cost;
-                Damage = damage;
-                Defense = defense;
-            }
-        }
-
-        internal abstract class Character
-        {
-            public int HitPoints { get; set; }
-            public int Damage { get; set; }
-            public int Defense { get; set; }
-        }
-
-        internal class Player : Character
-        {
-            Weapon _weapon;
-            Armor? _armor;
-            List<Ring> _rings;
-
-            public Weapon Weapon
-            {
-                get => _weapon;
-                set
-                {
-                    if (_weapon != value)
-                    {
-                        _weapon = value;
-                        GetDamage();
-                    }
-                }
-            }
-            public Armor? Armor
-            {
-                get => _armor;
-                set
-                {
-                    if (_armor != value)
-                    {
-                        _armor = value;
-                        GetDefense();
-                    }
-                }
-            }
-            public List<Ring> Rings
-            {
-                get => _rings;
-                set
-                {
-                    if (_rings != value)
-                    {
-                        _rings = value;
-                        if (_rings.Count > 0)
-                        {
-                            GetDamage();
-                            GetDefense();
-                        }
-                    }
-                }
-            }
-
-
-            public Player(int hitPoints, int damage, int defense)
-            {
-                HitPoints = hitPoints;
-                Damage = damage;
-                Defense = defense;
-                Rings = new();
-            }
-
-            public int GetCost()
-            {
-                var cost = Weapon.Cost;
-                if (Armor != null)
-                {
-                    cost += Armor.Cost;
-                }
-
-                cost += Rings.Select(x => x.Cost).Sum();
-
-                return cost;
-            }
-
-            public void GetDamage()
-            {
-                Damage = Weapon.Damage + Rings.Select(x => x.Damage).Sum();
-            }
-
-            public void GetDefense()
-            {
-                var armorDefense = 0;
-                if (Armor != null)
-                    armorDefense = Armor.Defense;
-                Defense = armorDefense + Rings.Select(x => x.Defense).Sum();
-            }
-
-            public void ChangeGear(Weapon weapon, Armor armor, List<Ring> rings)
-            {
-                Weapon = weapon;
-                Armor = armor;
-                Rings = rings;
-
-                GetDamage();
-                GetDefense();
-            }
-        }
-
-        internal class Boss : Character
-        {
-            public Boss(int hitPoints, int damage, int defense)
-            {
-                HitPoints = hitPoints;
-                Damage = damage;
-                Defense = defense;
-            }
-        }
         #endregion
 
         #endregion

--- a/AdventOfCode2015/Problems/Day22.cs
+++ b/AdventOfCode2015/Problems/Day22.cs
@@ -1,4 +1,8 @@
-﻿namespace AdventOfCode2015.Problems
+﻿using AdventOfCode2015.CommonInternalTypes.Classes;
+using CommonTypes.CommonTypes.Regex;
+using static AdventOfCode2015.Problems.Day22;
+
+namespace AdventOfCode2015.Problems
 {
     public class Day22 : DayBase
     {
@@ -7,11 +11,12 @@
         string _inputPath = string.Empty;
         long _firstResult = 0;
         long _secondResult = 0;
-        long _sum = 0;
-        int[] _secretNumbers = [];
-        HashSet<(int diff1, int diff2, int diff3, int diff4)> _uniqueDifferences = new();
-        Dictionary<(int diff1, int diff2, int diff3, int diff4), long> _differenceCountTotal = new Dictionary<(int diff1, int diff2, int diff3, int diff4), long>();
-
+        Boss _boss = new();
+        Player _player = new(50, 500);
+        Dictionary<int, Spell> _spells = [];
+        HashSet<RunDetails> _allRunDetails = new();
+        List<RunDetails> _successfulRuns = new();
+        List<RunDetails> _failedRuns = new();
 
         #endregion
 
@@ -51,17 +56,6 @@
                 }
             }
         }
-        long Sum
-        {
-            get => _sum;
-            set
-            {
-                if (_sum != value)
-                {
-                    _sum = value;
-                }
-            }
-        }
         #endregion
 
         #region Constructor
@@ -78,12 +72,18 @@
         #region Methods
         public override void InitialiseProblem()
         {
-            var input = File.ReadAllLines(_inputPath);
-            _secretNumbers = new int[input.Length];
-            for (int i = 0; i < input.Length; i++)
+            var input = File.ReadAllText(_inputPath);
+            var bossStats = CommonRegexHelpers.NumberRegex().Matches(input);
+            _boss = new Boss(int.Parse(bossStats[0].Value), int.Parse(bossStats[1].Value), 0);
+            _spells = new Dictionary<int, Spell>()
             {
-                _secretNumbers[i] = int.Parse(input[i]);
-            }
+                { 1, new Spell("Magic Missile", 53, 4, 0, 0, 0, 0) },
+                { 2, new Spell("Drain", 73, 2, 0, 2, 0, 0) },
+                { 3, new Spell("Shield", 113, 0, 7, 0, 0, 6) },
+                { 4, new Spell("Poison", 173, 3, 0, 0, 0, 6) },
+                { 5, new Spell("Recharge", 229, 0, 0, 0, 101, 5) },
+            };
+
         }
 
         public override void OutputSolution()
@@ -94,81 +94,162 @@
 
         public override T SolveFirstProblem<T>()
         {
-            Sum = 0;
-            foreach (var secretNumber in _secretNumbers)
-            {
-                List<int> allDifferences = new();
-                long secretNumberCopy = secretNumber;
-                var iter = 0;
 
-                HashSet<(int, int, int, int)> processedPatternsForCurrentSecret = new();
 
-                while (iter < 2000)
-                {
-                    var secretNumberInitialLastDigit = GetLastDigit(secretNumberCopy);
-                    secretNumberCopy = ProcessSecretNumber(secretNumberCopy);
-                    var secretNumberEvolvedLastDigit = GetLastDigit(secretNumberCopy);
-                    var secretNumberDifference = secretNumberEvolvedLastDigit - secretNumberInitialLastDigit;
-                    allDifferences.Add(secretNumberDifference);
-                    if (iter >= 3)
-                    {
-                        var previous4Differences = allDifferences.Skip(Math.Max(0, allDifferences.Count() - 4)).ToList();
-                        (int diff1, int diff2, int diff3, int diff4) differencePattern = (previous4Differences[0], previous4Differences[1], previous4Differences[2], previous4Differences[3]);
-
-                        if (_uniqueDifferences.Add(differencePattern))
-                        {
-                            _differenceCountTotal[differencePattern] = secretNumberEvolvedLastDigit;
-                            processedPatternsForCurrentSecret.Add(differencePattern);
-                        }
-                        else
-                        {
-                            if (!processedPatternsForCurrentSecret.Contains(differencePattern))
-                            {
-                                _differenceCountTotal[differencePattern] += secretNumberEvolvedLastDigit;
-                                processedPatternsForCurrentSecret.Add(differencePattern);
-                            }
-                        }
-                    }
-
-                    iter++;
-                }
-                Sum += secretNumberCopy;
-            }
-            return (T)Convert.ChangeType(Sum, typeof(T));
+            return (T)Convert.ChangeType(0, typeof(T));
         }
 
         public override T SolveSecondProblem<T>()
         {
-            Sum = _differenceCountTotal.OrderByDescending(x => x.Value).First().Value;
-            return (T)Convert.ChangeType(Sum, typeof(T));
+            return (T)Convert.ChangeType(0, typeof(T));
         }
 
-        long ProcessSecretNumber(long secretNumber)
+
+        private void RunTurn(ref RunDetails runDetails)
         {
-            // Step 1: Multiply by 64, mix, and prune
-            secretNumber = MixAndPrune(secretNumber, secretNumber * 64);
+            runDetails.GameState = PlayerAttack(runDetails);
+            if (runDetails.GameState == GameState.Success)
+                return;
 
-            // Step 2: Divide by 32 (round down), mix, and prune
-            secretNumber = MixAndPrune(secretNumber, secretNumber / 32);
-
-            // Step 3: Multiply by 2048, mix, and prune
-            secretNumber = MixAndPrune(secretNumber, secretNumber * 2048);
-
-            return secretNumber;
+            runDetails.GameState = BossAttack(runDetails.Boss, runDetails.Player);
         }
 
-        long MixAndPrune(long secretNumber, long value)
+        private GameState BossAttack(Boss boss, Player player)
         {
-            // Mix: XOR the secret number with the value
-            long mixedNumber = secretNumber ^ value;
+            if (boss.EffectTimer > 0)
+            {
+                boss.HitPoints -= 3;
+                boss.EffectTimer--;
+                if (boss.HitPoints <= 0)
+                    return GameState.Success;
+            }
 
-            // Prune: Modulo operation
-            return mixedNumber % 16777216;
+            var totalDamage = boss.Damage - player.Defense;
+            if (totalDamage <= 0)
+                totalDamage = 1;
+            if (player.HitPoints <= 0)
+                return GameState.Failed;
+
+            player.HitPoints -= totalDamage;
+
+            return GameState.InProgress;
         }
 
-        int GetLastDigit(long secretNumber)
+        private GameState PlayerAttack(RunDetails runDetails)
         {
-            return int.Parse(secretNumber.ToString().Last().ToString());
+            var newQueue = new Queue<Spell>();
+            foreach (var spell in runDetails.SpellQueue)
+            {
+                runDetails.TotalManaSpent += spell.ManaCost;
+
+                if (spell.Damage > 0 && spell.EffectTimer > 0)
+                    runDetails.Boss.EffectTimer = spell.EffectTimer;
+                else
+                    runDetails.Boss.HitPoints -= spell.Damage;
+
+                runDetails.Player.HitPoints += spell.Heal;
+
+                runDetails.Player.Defense += spell.Defense;
+                runDetails.Player.Mana += spell.ManaReturn;
+            }
+
+            return GameState.InProgress;
+        }
+
+        void BreadthFirstSearch()
+        {
+            var queue = new Queue<RunDetails>(new[] 
+            { 
+                new RunDetails() { Player = _player, Boss = _boss, MagicMissileCount = 1, SpellQueue = new Queue<Spell>(new [] { _spells[1] }) },
+                new RunDetails() { Player = _player, Boss = _boss, DrainCount = 1, SpellQueue = new Queue<Spell>(new [] { _spells[2] }) },
+                new RunDetails() { Player = _player, Boss = _boss, ShieldCount = 1, SpellQueue = new Queue<Spell>(new [] { _spells[3] }) },
+                new RunDetails() { Player = _player, Boss = _boss, PoisonCount = 1, SpellQueue = new Queue<Spell>(new [] { _spells[4] }) },
+                new RunDetails() { Player = _player, Boss = _boss, RechargeCount = 1, SpellQueue = new Queue<Spell>(new [] { _spells[5] }) },
+            });
+            var visitedSequences = new HashSet<(int magicMissileCount, int drainCount, int shieldCount, int poisonCount, int rechargeCount)>();
+
+            while (queue.Count() != 0)
+            {
+                var currentRunDetails = queue.Dequeue();
+                RunTurn(ref currentRunDetails);
+
+                if (currentRunDetails.GameState == GameState.Success)
+                    _successfulRuns.Add(currentRunDetails);
+                else if (currentRunDetails.GameState == GameState.Failed)
+                    _failedRuns.Add(currentRunDetails);
+                else
+                {
+
+                    if (!visitedSequences.Add(currentRunDetails.GetRunHashSet()))
+                        continue;
+
+                    RunDetails runCopy = new();
+
+                    runCopy = currentRunDetails;
+                    runCopy.MagicMissileCount++;
+                    runCopy.SpellQueue.Enqueue(_spells[1]);
+                    queue.Enqueue(runCopy);
+
+                    runCopy = currentRunDetails;
+                    runCopy.DrainCount++;
+                    runCopy.SpellQueue.Enqueue(_spells[2]);
+                    queue.Enqueue(runCopy);
+
+                    runCopy = currentRunDetails;
+                    runCopy.ShieldCount++;
+                    runCopy.SpellQueue.Enqueue(_spells[3]);
+                    queue.Enqueue(runCopy);
+
+                    runCopy = currentRunDetails;
+                    runCopy.PoisonCount++;
+                    runCopy.SpellQueue.Enqueue(_spells[4]);
+                    queue.Enqueue(runCopy);
+
+                    runCopy = currentRunDetails;
+                    runCopy.RechargeCount++;
+                    runCopy.SpellQueue.Enqueue(_spells[5]);
+                    queue.Enqueue(runCopy);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Treating this like a roguelike, we can treat each branching path of the search as a different run. 
+        /// By counting the instances of each spell cast we can ignore duplicate scenarios where the spell 1 is cast before spell 2 but both are called once.
+        /// e.g. (Spell1++ -> Spell2++) and (Spell2++ -> Spell1++) are the same
+        /// 
+        /// </summary>
+        internal class RunDetails
+        {
+            public int MagicMissileCount { get; set; } = 0;
+            public int DrainCount { get; set; } = 0;
+            public int ShieldCount { get; set; } = 0;
+            public int PoisonCount { get; set; } = 0;
+            public int RechargeCount { get; set; } = 0;
+            public int TotalManaSpent { get; set; } = 0;
+
+            public Player Player { get; set; }
+            public Boss Boss { get; set; }
+            public GameState GameState { get; set; }
+            public Queue<Spell> SpellQueue { get; set; } = new();
+
+            public RunDetails()
+            {
+                GameState = GameState.InProgress;
+                SpellQueue = new Queue<Spell>();
+            }
+
+            public (int, int, int, int, int) GetRunHashSet()
+            {
+                return (MagicMissileCount, DrainCount, ShieldCount, PoisonCount, RechargeCount);
+            }
+        }
+
+        internal enum GameState
+        {
+            InProgress = 0,
+            Success = 1,
+            Failed = 2,
         }
         #endregion
     }

--- a/AdventOfCode2015/Problems/Day22.cs
+++ b/AdventOfCode2015/Problems/Day22.cs
@@ -64,7 +64,7 @@ namespace AdventOfCode2015.Problems
         {
             _inputPath = inputPath;
             InitialiseProblem();
-            //FirstResult = SolveFirstProblem<int>();
+            FirstResult = SolveFirstProblem<int>();
             SecondResult = SolveSecondProblem<int>();
             OutputSolution();
         }
@@ -112,7 +112,7 @@ namespace AdventOfCode2015.Problems
             var totalManaSpent = BreadthFirstSearch();
             return (T)Convert.ChangeType(totalManaSpent, typeof(T));
         }
-        //1295 too high
+
         private void BossAttack(RunDetails runDetails)
         {
             ApplyDOTEffects(runDetails);
@@ -258,7 +258,10 @@ namespace AdventOfCode2015.Problems
 
                 if (currentRunDetails.GameState == GameState.Success)
                 {
-                    _successfulRuns.Add(currentRunDetails);
+                    if (_successfulRuns.Count != 1000)
+                        _successfulRuns.Add(currentRunDetails);
+                    else
+                        break;
                 }
                 else if (currentRunDetails.GameState == GameState.Failed)
                     _failedRuns.Add(currentRunDetails);
@@ -289,7 +292,7 @@ namespace AdventOfCode2015.Problems
                     queue.Enqueue(currentSpellQueueCopy);
 
                     // Apply shield spell only if effect timer is 0
-                    if (currentRunDetails.Player.DefenseTimer == 0)
+                    if (currentRunDetails.Player.DefenseTimer == 0 || currentRunDetails.Player.DefenseTimer == 1)
                     {
                         currentSpellQueueCopy = new Queue<Spell>(currentSpellQueue);
                         currentSpellQueueCopy.Enqueue(_spells["Shield"]);
@@ -297,7 +300,7 @@ namespace AdventOfCode2015.Problems
                     }
 
                     // Apply poison spell only if effect timer is 0
-                    if (currentRunDetails.Boss.EffectTimer == 0)
+                    if (currentRunDetails.Boss.EffectTimer == 0 || currentRunDetails.Boss.EffectTimer == 1)
                     {
                         currentSpellQueueCopy = new Queue<Spell>(currentSpellQueue);
                         currentSpellQueueCopy.Enqueue(_spells["Poison"]);
@@ -305,7 +308,7 @@ namespace AdventOfCode2015.Problems
                     }
 
                     // Apply recharge spell only if effect timer is 0
-                    if (currentRunDetails.Player.RechargeTimer == 0)
+                    if (currentRunDetails.Player.RechargeTimer == 0 || currentRunDetails.Player.RechargeTimer == 1)
                     {
                         currentSpellQueueCopy = new Queue<Spell>(currentSpellQueue);
                         currentSpellQueueCopy.Enqueue(_spells["Recharge"]);
@@ -313,8 +316,6 @@ namespace AdventOfCode2015.Problems
                     }
                 }
             }
-            var temp = _successfulRuns.DistinctBy(x => x.TotalManaSpent).ToList();
-            var temp1 = temp.OrderBy(x => x.TotalManaSpent).ToList();
 
             return _successfulRuns.DistinctBy(x => x.TotalManaSpent).Select(x => x.TotalManaSpent).Min();
         }

--- a/AdventOfCode2015Tests/Day22.cs
+++ b/AdventOfCode2015Tests/Day22.cs
@@ -3,20 +3,6 @@ namespace AdventOfCode2015Tests
     [TestClass]
     public class Day22
     {
-        [TestMethod]
-        [DeploymentItem("Inputs/Day22/Day22Test1.txt")]
-        public void Part1_ProducesCorrect2000thSecretNumber_IsTrue()
-        {
-            var instance = new AdventOfCode2015.Problems.Day22("Day22Test1.txt");
-            instance.FirstResult.Should().Be(37327623);
-        }
-
-        [TestMethod]
-        [DeploymentItem("Inputs/Day22/Day22Test2.txt")]
-        public void Part2_ProducesCorrectTotalBananas_IsTrue()
-        {
-            var instance = new AdventOfCode2015.Problems.Day22("Day22Test2.txt");
-            instance.SecondResult.Should().Be(23);
-        }
+        // No tests since there's no test data
     }
 }


### PR DESCRIPTION
Implemented a BFS algorithm to find the optimal minimal mana cost to beat the boss

Both parts utilise the same search which enqueues a spell queue to attempt a run against, if neither the boss or player is dead then we enqueue another set of spell and repeat until either the player is dead, out of mana, or killed the boss.

Part 2 adds a simple check before each spell is applied to remove 1 hit point from the player