### PR TITLE
Implemented 2016 Day 7 solution

### DIFF
--- a/AdventOfCode2016/Menu2016.cs
+++ b/AdventOfCode2016/Menu2016.cs
@@ -35,6 +35,8 @@ public static class Menu2016
                             _ = new Day6(@"..\..\..\..\AdventOfCode2016\Inputs\Puzzles\Day6Puzzle.txt");
                             break;
                         case 7:
+                            _ = new Day7(@"..\..\..\..\AdventOfCode2016\Inputs\Puzzles\Day7Puzzle.txt");
+                            break;
                         case 8:
                         case 9:
                         case 10:

--- a/AdventOfCode2016/Problems/Day7.cs
+++ b/AdventOfCode2016/Problems/Day7.cs
@@ -87,51 +87,26 @@ namespace AdventOfCode2016.Problems
         public override T SolveSecondProblem<T>()
         {
             var result = 0;
-            var bracketsContainingSslRegex = BracketsSupportingSSL();
             var sslRegex = SingleLetterRepeatedAfterAnotherLetter();
             var bracketRegex = StringWithinBrackets();
 
-            var potentialSslSupportedIpAddresses = _ipAddresses.Where(x => bracketsContainingSslRegex.IsMatch(x)).ToArray();
-            var temp2 = potentialSslSupportedIpAddresses.Where(x => bracketsContainingSslRegex.IsMatch(x)).Select(xx => bracketsContainingSslRegex.Matches(xx).Select(x => x.Value).ToArray()).ToArray();
-            var temp3 = new List<string>();
-            foreach (var x in temp2)
+            var potentialSslSupportedIpAddresses = _ipAddresses.Where(x => bracketRegex.IsMatch(x)).ToArray();
+
+            foreach (var ipAddress in potentialSslSupportedIpAddresses)
             {
-                foreach (var y in x)
-                {
-                    var temp4 = sslRegex.Matches(y).Select(x => x.Value).ToArray();
-                    temp3.AddRange(temp4);
-                }
-            }
+                var hypernets = bracketRegex.Matches(ipAddress).Select(x => x.Groups[1].Value).ToArray();
+                var supernets = bracketRegex.Replace(ipAddress, "-").Split("-");
 
-            foreach ( var ipAddress in potentialSslSupportedIpAddresses)
-            {
-                var sslBracket = bracketsContainingSslRegex.Match(ipAddress).Value;
-                var sslOptions = sslRegex.Matches(sslBracket).Select(x => x.Value).ToArray();
-                var supernet = bracketRegex.Replace(ipAddress, ""); //reduce the string to only look at the supernet sequence of chars
+                var sslOptions = supernets.SelectMany(x => sslRegex.Matches(x).Select(x => x.Groups[1].Value + x.Groups[2].Value + x.Groups[1].Value)).ToArray();
+                var invertedSslOptions = sslOptions.Select(InvertSSLValue).ToHashSet();
 
-                foreach (var ssl in sslOptions)
-                {
-                    //Skip options like "vvv" or "ddd"
-                    if (ssl.Distinct().Count() == 1)
-                        continue;
-
-                    var inverseSSL = InvertSSLValue(ssl);
-                    if (supernet.Contains(inverseSSL))
-                    {
-                        result++;
-                        break;
-                    }
-                }
-
-
-
+                if (hypernets.Any(hyper => invertedSslOptions.Any(invertedSsl => hyper.Contains(invertedSsl))))
+                    result++;
             }
 
             return (T)Convert.ChangeType(result, typeof(T));
-            //282 too High
-            //192 too low
-            //189
         }
+
 
         string InvertSSLValue(string ssl)
         {
@@ -153,19 +128,15 @@ namespace AdventOfCode2016.Problems
         [GeneratedRegex(@"(.)\1{3}")]
         private static partial Regex PalindromesWithoutCharDifference();
 
-
-        //https://regex101.com/r/9xqoR5/1
-        [GeneratedRegex(@"\[[^\]]*(.)\w\1[^\]]*\]")]
-        private static partial Regex BracketsSupportingSSL();
-
-        //https://regex101.com/r/r7gXs3/1
-        [GeneratedRegex(@"(.).\1")]
+        //https://regex101.com/r/Qopg0k/1
+        [GeneratedRegex(@"(?=(.)(.)\1)")]
         private static partial Regex SingleLetterRepeatedAfterAnotherLetter();
 
 
-        //https://regex101.com/r/SfZIeb/1
-        [GeneratedRegex(@"\[[^\][^\]]*\]")]
+        //https://regex101.com/r/SfZIeb/2
+        [GeneratedRegex(@"\[([^\]]+)\]")]
         private static partial Regex StringWithinBrackets();
+
         #endregion
     }
 }

--- a/AdventOfCode2016/Problems/Day7.cs
+++ b/AdventOfCode2016/Problems/Day7.cs
@@ -1,0 +1,171 @@
+﻿using CommonTypes.CommonTypes.Classes;
+using System.Text.RegularExpressions;
+
+namespace AdventOfCode2016.Problems
+{
+    public partial class Day7 : DayBase
+    {
+        #region Fields
+        string _inputPath = string.Empty;
+        int _firstResult = 0;
+        int _secondResult = 0;
+        string[] _ipAddresses = [];
+
+        #endregion
+
+        #region Properties
+        protected override string InputPath
+        {
+            get => _inputPath;
+            set
+            {
+                if (_inputPath != value)
+                {
+                    _inputPath = value;
+                }
+            }
+        }
+        public Result<int> FirstResult
+        {
+            get => _firstResult;
+            set
+            {
+                if (_firstResult != value)
+                {
+                    _firstResult = value;
+                }
+            }
+        }
+        public Result<int> SecondResult
+        {
+            get => _secondResult;
+            set
+            {
+                if (_secondResult != value)
+                {
+                    _secondResult = value;
+                }
+            }
+        }
+        #endregion
+
+        #region Constructor
+        public Day7(string inputPath)
+        {
+            _inputPath = inputPath;
+            InitialiseProblem();
+            FirstResult = SolveFirstProblem<int>();
+            SecondResult = SolveSecondProblem<int>();
+            OutputSolution();
+        }
+        #endregion
+
+        #region Methods
+        public override void InitialiseProblem()
+        {
+            _ipAddresses = File.ReadAllLines(_inputPath);
+        }
+
+        public override void OutputSolution()
+        {
+            Console.WriteLine($"First Solution is: {FirstResult}");
+            Console.WriteLine($"Second Solution is: {SecondResult}");
+        }
+
+        public override T SolveFirstProblem<T>()
+        {
+            var validIpRegex = FourCharacterPalindrome();
+            var bracketIpRegex = PalindromesWithinBrackets();
+            var noCharDifferenceRegex = PalindromesWithoutCharDifference();
+
+            var tlsSupportedIpAddresses = _ipAddresses.Where(x => !bracketIpRegex.IsMatch(x) && !noCharDifferenceRegex.IsMatch(x) && validIpRegex.IsMatch(x)).ToArray();
+
+            var result = tlsSupportedIpAddresses.Count();
+
+            return (T)Convert.ChangeType(result, typeof(T));
+        }
+        public override T SolveSecondProblem<T>()
+        {
+            var result = 0;
+            var bracketsContainingSslRegex = BracketsSupportingSSL();
+            var sslRegex = SingleLetterRepeatedAfterAnotherLetter();
+            var bracketRegex = StringWithinBrackets();
+
+            var potentialSslSupportedIpAddresses = _ipAddresses.Where(x => bracketsContainingSslRegex.IsMatch(x)).ToArray();
+            var temp2 = potentialSslSupportedIpAddresses.Where(x => bracketsContainingSslRegex.IsMatch(x)).Select(xx => bracketsContainingSslRegex.Matches(xx).Select(x => x.Value).ToArray()).ToArray();
+            var temp3 = new List<string>();
+            foreach (var x in temp2)
+            {
+                foreach (var y in x)
+                {
+                    var temp4 = sslRegex.Matches(y).Select(x => x.Value).ToArray();
+                    temp3.AddRange(temp4);
+                }
+            }
+
+            foreach ( var ipAddress in potentialSslSupportedIpAddresses)
+            {
+                var sslBracket = bracketsContainingSslRegex.Match(ipAddress).Value;
+                var sslOptions = sslRegex.Matches(sslBracket).Select(x => x.Value).ToArray();
+                var supernet = bracketRegex.Replace(ipAddress, ""); //reduce the string to only look at the supernet sequence of chars
+
+                foreach (var ssl in sslOptions)
+                {
+                    //Skip options like "vvv" or "ddd"
+                    if (ssl.Distinct().Count() == 1)
+                        continue;
+
+                    var inverseSSL = InvertSSLValue(ssl);
+                    if (supernet.Contains(inverseSSL))
+                    {
+                        result++;
+                        break;
+                    }
+                }
+
+
+
+            }
+
+            return (T)Convert.ChangeType(result, typeof(T));
+            //282 too High
+            //192 too low
+            //189
+        }
+
+        string InvertSSLValue(string ssl)
+        {
+            return ssl[1].ToString() + ssl[0].ToString() + ssl[1].ToString();
+        }
+
+
+        //https://regex101.com/r/LzFreu/1
+        [GeneratedRegex(@"(.)(.)\2\1")]
+        private static partial Regex FourCharacterPalindrome();
+
+
+        //https://regex101.com/r/uRomNr/2
+        [GeneratedRegex(@"\[[^\]]*(.)(.)\2\1[^\]]*\]")]
+        private static partial Regex PalindromesWithinBrackets();
+
+
+        //https://regex101.com/r/Xca3zz/2
+        [GeneratedRegex(@"(.)\1{3}")]
+        private static partial Regex PalindromesWithoutCharDifference();
+
+
+        //https://regex101.com/r/9xqoR5/1
+        [GeneratedRegex(@"\[[^\]]*(.)\w\1[^\]]*\]")]
+        private static partial Regex BracketsSupportingSSL();
+
+        //https://regex101.com/r/r7gXs3/1
+        [GeneratedRegex(@"(.).\1")]
+        private static partial Regex SingleLetterRepeatedAfterAnotherLetter();
+
+
+        //https://regex101.com/r/SfZIeb/1
+        [GeneratedRegex(@"\[[^\][^\]]*\]")]
+        private static partial Regex StringWithinBrackets();
+        #endregion
+    }
+}

--- a/AdventOfCode2016Tests/AdventOfCode2016Tests.csproj
+++ b/AdventOfCode2016Tests/AdventOfCode2016Tests.csproj
@@ -101,6 +101,30 @@
     <None Update="Inputs\Day5\Day5Test1.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Inputs\Day7\Day7Test8.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day7\Day7Test7.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day7\Day7Test6.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day7\Day7Test5.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day7\Day7Test4.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day7\Day7Test3.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day7\Day7Test2.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day7\Day7Test1.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/AdventOfCode2016Tests/Day7.cs
+++ b/AdventOfCode2016Tests/Day7.cs
@@ -1,0 +1,64 @@
+namespace AdventOfCode2016Tests
+{
+    [TestClass]
+    public class Day7
+    {
+        [TestMethod]
+        [DeploymentItem("Inputs/Day7/Day7Test1.txt")]
+        public void Part1_OutputsValidIpAddressCountFile1_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day7("Day7Test1.txt");
+            instance.FirstResult.ResultValue.Should().Be(1);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day7/Day7Test2.txt")]
+        public void Part1_OutputsValidIpAddressCountFile2_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day7("Day7Test2.txt");
+            instance.FirstResult.ResultValue.Should().Be(0);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day7/Day7Test3.txt")]
+        public void Part1_OutputsValidIpAddressCountFile3_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day7("Day7Test3.txt");
+            instance.FirstResult.ResultValue.Should().Be(0);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day7/Day7Test4.txt")]
+        public void Part1_OutputsValidIpAddressCountFile4_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day7("Day7Test4.txt");
+            instance.FirstResult.ResultValue.Should().Be(1);
+        }
+
+        [TestMethod]
+        [DeploymentItem("Inputs/Day7/Day7Test5.txt")]
+        public void Part2_OutputsSslSupportedIpAddressesFile5_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day7("Day7Test5.txt");
+            instance.SecondResult.ResultValue.Should().Be(1);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day7/Day7Test6.txt")]
+        public void Part2_OutputsSslSupportedIpAddressesFile6_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day7("Day7Test6.txt");
+            instance.SecondResult.ResultValue.Should().Be(0);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day7/Day7Test7.txt")]
+        public void Part2_OutputsSslSupportedIpAddressesFile7_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day7("Day7Test7.txt");
+            instance.SecondResult.ResultValue.Should().Be(1);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day7/Day7Test8.txt")]
+        public void Part2_OutputsSslSupportedIpAddressesFile8_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day7("Day7Test8.txt");
+            instance.SecondResult.ResultValue.Should().Be(1);
+        }
+    }
+}


### PR DESCRIPTION
Implemented solution for finding the TLS and SSL supported IP addresses from the provided puzzle.

Both parts use regex to find the required data matches. Part 1 simply finds ip addresses which match/dont match the rules.

Part 2 specifically separates the supernets and hypernets using regex. The supernets are then matched for ssl options e.g. xyx, aba [..], which are then inverted and used to compare with the hypernets for matches. 