### PR TITLE
Solved 2016 Day 17

### DIFF
--- a/AdventOfCode2016/Menu2016.cs
+++ b/AdventOfCode2016/Menu2016.cs
@@ -66,6 +66,8 @@ public static class Menu2016
                             _ = new Day16(@"..\..\..\..\AdventOfCode2016\Inputs\Puzzles\Day16Puzzle.txt", 272);
                             break;
                         case 17:
+                            _ = new Day17(@"..\..\..\..\AdventOfCode2016\Inputs\Puzzles\Day17Puzzle.txt");
+                            break;
                         case 18:
                         case 19:
                         case 20:

--- a/AdventOfCode2016/Problems/Day17.cs
+++ b/AdventOfCode2016/Problems/Day17.cs
@@ -1,0 +1,223 @@
+﻿using CommonTypes.CommonTypes.Classes;
+using CommonTypes.CommonTypes.Constants;
+using CommonTypes.CommonTypes.Enums;
+using System.Security.Cryptography;
+using System;
+using System.Text.RegularExpressions;
+using System.IO;
+
+namespace AdventOfCode2016.Problems
+{
+    public partial class Day17 : DayBase
+    {
+        #region Fields
+        string _inputPath = string.Empty;
+        string _firstResult = string.Empty;
+        int _secondResult = 0;
+        string _passcode = string.Empty;
+        Node _start = new();
+        Node _target = new();
+        Node _currentPosition = new();
+        bool[,] _positions = new bool[0, 0];
+        (int dx, int dy, Direction direction)[] _directions = DirectionConstants.GetBasicDirections();
+        Regex _capitalLetterRegex = CapitalLetterRegex();
+        List<string> _validPasscodes = new();
+        int _min = int.MaxValue;
+        int _max = 0;
+
+        #endregion
+
+        #region Properties
+        protected override string InputPath
+        {
+            get => _inputPath;
+            set
+            {
+                if (_inputPath != value)
+                {
+                    _inputPath = value;
+                }
+            }
+        }
+        public string FirstResult
+        {
+            get => _firstResult;
+            set
+            {
+                if (_firstResult != value)
+                {
+                    _firstResult = value;
+                }
+            }
+        }
+        public int SecondResult
+        {
+            get => _secondResult;
+            set
+            {
+                if (_secondResult != value)
+                {
+                    _secondResult = value;
+                }
+            }
+        }
+        #endregion
+
+        #region Constructor
+        public Day17(string inputPath)
+        {
+            _inputPath = inputPath;
+            InitialiseProblem();
+            FirstResult = SolveFirstProblem<string>();
+            SecondResult = SolveSecondProblem<int>();
+            OutputSolution();
+        }
+        #endregion
+
+        #region Methods
+        public override void InitialiseProblem()
+        {
+            _passcode = File.ReadAllText(_inputPath);
+            _start = new() { X = 0, Y = 0 };
+            _currentPosition = new() { X = 0, Y = 0 };
+            _target = new() { X = 3, Y = 3 };
+            _validPasscodes = new();
+
+            FindAllPaths(_start, _target);
+        }
+
+        public override void OutputSolution()
+        {
+            Console.WriteLine($"First Solution is: {FirstResult}");
+            Console.WriteLine($"Second Solution is: {SecondResult}");
+        }
+
+        public override T SolveFirstProblem<T>()
+        {
+            //FindShortestPath(_positions, _start, _target, false);
+            var result = _validPasscodes.First();
+            var path = _capitalLetterRegex.Match(result).Value;
+            return (T)Convert.ChangeType(path, typeof(T));
+        }
+        public override T SolveSecondProblem<T>()
+        {
+            _validPasscodes = new();
+            //FindShortestPath(_positions, _start, _target, true);
+            var result = _validPasscodes.First();
+            var path = _capitalLetterRegex.Match(result).Value;
+            return (T)Convert.ChangeType(path.Length, typeof(T));
+        }
+
+
+        void FindAllPaths(Node start, Node target)
+        {
+            var distances = new Dictionary<(int y, int x, Direction direction, string passcode), string>();
+            var priorityQueue = new PriorityQueue<(Node, string), int>();
+            //var queue = new Queue<(Node, string)>();
+
+            priorityQueue.Enqueue((start, _passcode), 0);
+
+            while (priorityQueue.Count > 0)
+            {
+                (Node currentPosition, string passcode) current = priorityQueue.Dequeue();
+
+
+                if (current.currentPosition.X == _target.X && current.currentPosition.Y == _target.Y)
+                {
+                    _min = Math.Min(_min, current.passcode.Length);
+                    _max = Math.Max(_max, current.passcode.Length);
+                    //_validPasscodes.Add(current.passcode);
+                }
+
+                //if (!distances.TryAdd((current.currentPosition.Y, current.currentPosition.X, current.currentPosition.Direction, current.passcode), current.passcode))
+                //    continue;
+
+                var passcodeHash = GeneratePasscodeHash(current.passcode);
+
+                if (current.currentPosition.X > 0 && IsValidChar(passcodeHash[0]))
+                    priorityQueue.Enqueue((new Node { X = current.currentPosition.X - 1, Y = current.currentPosition.Y }, current.passcode + 'U'), -current.passcode.Length);
+
+                if (current.currentPosition.X < _target.X && IsValidChar(passcodeHash[1]))
+                    priorityQueue.Enqueue((new Node { X = current.currentPosition.X + 1, Y = current.currentPosition.Y }, current.passcode + 'D'), -current.passcode.Length);
+
+                if (current.currentPosition.Y > 0 && IsValidChar(passcodeHash[2]))
+                    priorityQueue.Enqueue((new Node { X = current.currentPosition.X, Y = current.currentPosition.Y - 1 }, current.passcode + 'L'), -current.passcode.Length);
+
+                if (current.currentPosition.Y < _target.Y && IsValidChar(passcodeHash[3]))
+                    priorityQueue.Enqueue((new Node { X = current.currentPosition.X, Y = current.currentPosition.Y + 1 }, current.passcode + 'R'), -current.passcode.Length);
+
+                //(int dx, int dy, Direction direction, bool unlocked)[] directions =
+                //[
+                //    (-1, 0, Direction.North, IsValidChar(passcodeHash[0])),
+                //    (1, 0, Direction.South, IsValidChar(passcodeHash[1])),
+                //    (0, -1, Direction.West, IsValidChar(passcodeHash[2])),
+                //    (0, 1, Direction.East, IsValidChar(passcodeHash[3])),
+                //];
+                //foreach (var direction in directions.Where(x => x.unlocked))
+                //{
+                //    int newX = current.currentPosition.X + direction.dx;
+                //    int newY = current.currentPosition.Y + direction.dy;
+
+                //    if (IsValidPosition(newY, newX, 3, 3))
+                //    {
+                //        var newPasscode = current.passcode + GetDirectionToAppend(direction.direction);
+                //        queue.Enqueue((new Node { X = newX, Y = newY }, newPasscode));
+                //        //if (!part2)
+                //        //    queue.Enqueue((new Node { X = newX, Y = newY }, newPasscode), _target.X - newX + _target.Y + newY);
+                //        //else
+                //        //{
+                //        //    var path = _capitalLetterRegex.Match(newPasscode).Value;
+                //        //    priorityQueue.Enqueue((new Node { X = newX, Y = newY }, newPasscode), -path.Length);
+                //        //}
+
+                //    }
+                //}
+            }
+
+            bool IsValidPosition(int x, int y, int rows, int cols)
+            {
+                return x >= 0 && y >= 0 && x <= rows && y <= cols;
+            }
+        }
+
+        string GeneratePasscodeHash(string passcode)
+        {
+            byte[] inputBytes = System.Text.Encoding.ASCII.GetBytes(passcode);
+            byte[] hashBytes = MD5.HashData(inputBytes);
+
+            return Convert.ToHexString(hashBytes).ToLower();
+        }
+
+        bool IsValidChar(char hashChar)
+        {
+            return hashChar >= 'b' && hashChar <= 'f';
+        }
+
+        char GetDirectionToAppend(Direction direction)
+        {
+            char appendingChar = 'U';
+            switch (direction)
+            {
+                case Direction.North:
+                    appendingChar = 'U';
+                    break;
+                case Direction.South:
+                    appendingChar = 'D';
+                    break;
+                case Direction.West:
+                    appendingChar = 'L';
+                    break;
+                case Direction.East:
+                    appendingChar = 'R';
+                    break;
+            }
+            return appendingChar;
+        }
+
+        //https://regex101.com/r/FPK6fi/2
+        [GeneratedRegex(@"[^a-z][A-Z]*")]
+        private static partial Regex CapitalLetterRegex();
+        #endregion
+
+    }
+}

--- a/AdventOfCode2016/Problems/Day17.cs
+++ b/AdventOfCode2016/Problems/Day17.cs
@@ -24,6 +24,7 @@ namespace AdventOfCode2016.Problems
         List<string> _validPasscodes = new();
         int _min = int.MaxValue;
         int _max = 0;
+        string _shortestPath = string.Empty;
 
         #endregion
 
@@ -125,6 +126,8 @@ namespace AdventOfCode2016.Problems
                 if (current.currentPosition.X == _target.X && current.currentPosition.Y == _target.Y)
                 {
                     _min = Math.Min(_min, current.passcode.Length);
+                    if (_min == current.passcode.Length)
+                        _shortestPath = current.passcode;
                     _max = Math.Max(_max, current.passcode.Length);
                     //_validPasscodes.Add(current.passcode);
                 }

--- a/AdventOfCode2016Tests/AdventOfCode2016Tests.csproj
+++ b/AdventOfCode2016Tests/AdventOfCode2016Tests.csproj
@@ -41,6 +41,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Inputs\Day17\Day17Test3.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day17\Day17Test2.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day17\Day17Test1.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Inputs\Day16\Day16Test1.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/AdventOfCode2016Tests/Day16.cs
+++ b/AdventOfCode2016Tests/Day16.cs
@@ -7,7 +7,7 @@ namespace AdventOfCode2016Tests
     {
         [TestMethod]
         [DeploymentItem("Inputs/Day16/Day16Test1.txt")]
-        public void Part1_OutputsCorrectChecksumFile6_IsTrue()
+        public void Part1_OutputsCorrectChecksumFile1_IsTrue()
         {
             var instance = new AdventOfCode2016.Problems.Day16("Day16Test1.txt", 20);
             instance.FirstResult.Should().Be("01100");

--- a/AdventOfCode2016Tests/Day17.cs
+++ b/AdventOfCode2016Tests/Day17.cs
@@ -7,46 +7,26 @@ namespace AdventOfCode2016Tests
     {
         [TestMethod]
         [DeploymentItem("Inputs/Day17/Day17Test1.txt")]
-        public void Part1_OutputsCorrectShortestPathDirectionsFile1_IsTrue()
+        public void Part1And2_OutputsShortestAndLongestPathSizeFile1_IsTrue()
         {
             var instance = new AdventOfCode2016.Problems.Day17("Day17Test1.txt");
             instance.FirstResult.Should().Be("DDRRRD");
-        }
-        [TestMethod]
-        [DeploymentItem("Inputs/Day17/Day17Test2.txt")]
-        public void Part1_OutputsCorrectShortestPathDirectionsFile2_IsTrue()
-        {
-            var instance = new AdventOfCode2016.Problems.Day17("Day17Test2.txt");
-            instance.FirstResult.Should().Be("DDUDRLRRUDRD");
-        }
-        [TestMethod]
-        [DeploymentItem("Inputs/Day17/Day17Test3.txt")]
-        public void Part1_OutputsCorrectShortestPathDirectionsFile3_IsTrue()
-        {
-            var instance = new AdventOfCode2016.Problems.Day17("Day17Test3.txt");
-            instance.FirstResult.Should().Be("DRURDRUDDLLDLUURRDULRLDUUDDDRR");
-        }
-
-
-        [TestMethod]
-        [DeploymentItem("Inputs/Day17/Day17Test1.txt")]
-        public void Part2_OutputsLongestPathSizeFile1_IsTrue()
-        {
-            var instance = new AdventOfCode2016.Problems.Day17("Day17Test1.txt");
             instance.SecondResult.Should().Be(370);
         }
         [TestMethod]
         [DeploymentItem("Inputs/Day17/Day17Test2.txt")]
-        public void Part2_OutputsLongestPathSizeFile2_IsTrue()
+        public void Part1And2_OutputsShortestAndLongestPathSizeFile2_IsTrue()
         {
             var instance = new AdventOfCode2016.Problems.Day17("Day17Test2.txt");
+            instance.FirstResult.Should().Be("DDUDRLRRUDRD");
             instance.SecondResult.Should().Be(492);
         }
         [TestMethod]
         [DeploymentItem("Inputs/Day17/Day17Test3.txt")]
-        public void Part2_OutputsLongestPathSizeFile3_IsTrue()
+        public void Part1And2_OutputsShortestAndLongestPathSizeFile3_IsTrue()
         {
             var instance = new AdventOfCode2016.Problems.Day17("Day17Test3.txt");
+            instance.FirstResult.Should().Be("DRURDRUDDLLDLUURRDULRLDUUDDDRR");
             instance.SecondResult.Should().Be(830);
         }
     }

--- a/AdventOfCode2016Tests/Day17.cs
+++ b/AdventOfCode2016Tests/Day17.cs
@@ -1,0 +1,53 @@
+using System.Drawing;
+
+namespace AdventOfCode2016Tests
+{
+    [TestClass]
+    public class Day17
+    {
+        [TestMethod]
+        [DeploymentItem("Inputs/Day17/Day17Test1.txt")]
+        public void Part1_OutputsCorrectShortestPathDirectionsFile1_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day17("Day17Test1.txt");
+            instance.FirstResult.Should().Be("DDRRRD");
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day17/Day17Test2.txt")]
+        public void Part1_OutputsCorrectShortestPathDirectionsFile2_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day17("Day17Test2.txt");
+            instance.FirstResult.Should().Be("DDUDRLRRUDRD");
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day17/Day17Test3.txt")]
+        public void Part1_OutputsCorrectShortestPathDirectionsFile3_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day17("Day17Test3.txt");
+            instance.FirstResult.Should().Be("DRURDRUDDLLDLUURRDULRLDUUDDDRR");
+        }
+
+
+        [TestMethod]
+        [DeploymentItem("Inputs/Day17/Day17Test1.txt")]
+        public void Part2_OutputsLongestPathSizeFile1_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day17("Day17Test1.txt");
+            instance.SecondResult.Should().Be(370);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day17/Day17Test2.txt")]
+        public void Part2_OutputsLongestPathSizeFile2_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day17("Day17Test2.txt");
+            instance.SecondResult.Should().Be(492);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day17/Day17Test3.txt")]
+        public void Part2_OutputsLongestPathSizeFile3_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day17("Day17Test3.txt");
+            instance.SecondResult.Should().Be(830);
+        }
+    }
+}

--- a/CommonTypes/CommonTypes/Constants/DirectionConstants.cs
+++ b/CommonTypes/CommonTypes/Constants/DirectionConstants.cs
@@ -1,0 +1,18 @@
+﻿using CommonTypes.CommonTypes.Enums;
+
+namespace CommonTypes.CommonTypes.Constants
+{
+    public static class DirectionConstants
+    {
+        public static (int dx, int dy, Direction direction)[] GetBasicDirections()
+        {
+            return new (int, int, Direction)[]
+            {
+                (0, 1, Direction.East),   // Right
+                (1, 0, Direction.South),  // Down
+                (0, -1, Direction.West),  // Left
+                (-1, 0, Direction.North)  // Up
+            };
+        }
+    }
+}


### PR DESCRIPTION
Implemented solution for 2016 Day 17 AoC

Both parts return data that is stored as part of the algorithm run through which we do as soon as the data has been intialised.

We run the algorithm once because it takes a long time to brute force. I initially tried a BFS approach using a queue, then a priority queue to try and hammer down the memory complexity. However this was still adding 100,000s of different path combinations that needed to be checked. 

Since this solution also had a huge time complexity, I took a look at other solutions on the subreddit to see if there was something I was missing. But from what I could see each solution also appeared to either use a stack or do a recursive iterative approach to forming the path.

So I pivoted to using a Recursive Depth First Search approach (IDDFS). Although I could see the speed gains by removing the memory storage, this still took forever to run through. Even now I am still not aware of how deep each test passcode can go. Therefore as a way to exit the for loop, I add a limit of 1000 depth to search through. If this answer was wrong I would up it by another 1000.

Fortunately this has worked, albeit I am not the most happy with the result. I will probably do some extra diagnostics and then in the future refactor with a hopefully quicker implementation