### PR TITLE
Solved 2016 Day 18

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,6 @@
 
 # CS8602: Dereference of a possibly null reference.
 dotnet_diagnostic.CS8602.severity = silent
+
+# CS8604: Possible null reference argument.
+dotnet_diagnostic.CS8604.severity = none

--- a/AdventOfCode2016/Menu2016.cs
+++ b/AdventOfCode2016/Menu2016.cs
@@ -69,6 +69,8 @@ public static class Menu2016
                             _ = new Day17(@"..\..\..\..\AdventOfCode2016\Inputs\Puzzles\Day17Puzzle.txt");
                             break;
                         case 18:
+                            _ = new Day18(@"..\..\..\..\AdventOfCode2016\Inputs\Puzzles\Day18Puzzle.txt", 40);
+                            break;
                         case 19:
                         case 20:
                         case 21:

--- a/AdventOfCode2016/Problems/Day18.cs
+++ b/AdventOfCode2016/Problems/Day18.cs
@@ -1,0 +1,159 @@
+﻿using CommonTypes.CommonTypes.Interfaces;
+
+namespace AdventOfCode2016.Problems
+{
+    public partial class Day18 : IDayBase
+    {
+        #region Fields
+        string _inputPath = string.Empty;
+        int _firstResult = 0;
+        long _secondResult = 0;
+        int _rowLimit = 0;
+        List<string> _grid = new(); 
+        string _initialState = string.Empty;
+
+        #endregion
+
+        #region Properties
+        string InputPath
+        {
+            get => _inputPath;
+            set
+            {
+                if (_inputPath != value)
+                {
+                    _inputPath = value;
+                }
+            }
+        }
+        public int FirstResult
+        {
+            get => _firstResult;
+            set
+            {
+                if (_firstResult != value)
+                {
+                    _firstResult = value;
+                }
+            }
+        }
+        public long SecondResult
+        {
+            get => _secondResult;
+            set
+            {
+                if (_secondResult != value)
+                {
+                    _secondResult = value;
+                }
+            }
+        }
+        #endregion
+
+        #region Constructor
+        public Day18(string inputPath, int rowLimit)
+        {
+            _inputPath = inputPath;
+            _rowLimit = rowLimit;
+            InitialiseProblem();
+            FirstResult = SolveFirstProblem<int>();
+            SecondResult = SolveSecondProblem<long>();
+            OutputSolution();
+        }
+        #endregion
+
+        #region Methods
+        public  void InitialiseProblem()
+        {
+            _initialState = File.ReadAllText(_inputPath);
+        }
+
+        public  void OutputSolution()
+        {
+            Console.WriteLine($"First Solution is: {FirstResult}");
+            Console.WriteLine($"Second Solution is: {SecondResult}");
+        }
+
+        public T SolveFirstProblem<T>() where T : IConvertible
+        {
+            _grid = new() { _initialState };
+
+            for (int i = 1; i < _rowLimit; i++)
+            {
+                _grid.Add(CreateRow(i));
+            }    
+
+            var result = _grid.SelectMany(x => x.ToList()).Where(x => x == '.').Count();
+
+            return (T)Convert.ChangeType(result, typeof(T));
+        }
+        public  T SolveSecondProblem<T>() where T : IConvertible
+        {
+            _grid = new() { _initialState };
+            _rowLimit = 400000;
+
+            for (int i = 1; i < _rowLimit; i++)
+            {
+                _grid.Add(CreateRow(i));
+            }
+
+            var result = _grid.SelectMany(x => x.ToList()).Where(x => x == '.').Count();
+
+            return (T)Convert.ChangeType(result, typeof(T));
+        }
+
+        string CreateRow(int currentRowIterator)
+        {
+            var previousRow = _grid[currentRowIterator - 1];
+            var currentRow = string.Empty;
+            for (int i = 0; i < _grid[0].Length; i++)
+            {
+                var left = i - 1;
+                var center = i;
+                var right = i + 1;
+
+                var leftIsSafe = false;
+                var centerIsSafe = false;
+                var rightIsSafe = false;
+
+                if (left < 0)
+                    leftIsSafe = true;
+                else
+                    leftIsSafe = previousRow[left] == '.' ? true : false;
+
+                if (right > _grid[0].Length - 1)
+                    rightIsSafe = true;
+                else
+                    rightIsSafe = previousRow[right] == '.' ? true : false;
+
+                centerIsSafe = previousRow[center] == '.' ? true : false;
+
+                var isNotSafe = CalculateSafety(leftIsSafe, centerIsSafe, rightIsSafe);
+                currentRow += isNotSafe ? '^' : '.';
+            }
+            return currentRow;
+        }
+
+        bool CalculateSafety(bool leftIsSafe, bool centerIsSafe, bool rightIsSafe )
+        {
+            var isNotSafe = false;
+            isNotSafe = !leftIsSafe && !centerIsSafe && rightIsSafe;
+            if (isNotSafe)
+                return isNotSafe;
+            isNotSafe = leftIsSafe && !centerIsSafe && !rightIsSafe;
+            if (isNotSafe)
+                return isNotSafe;
+            isNotSafe = !leftIsSafe && centerIsSafe && rightIsSafe;
+            if (isNotSafe)
+                return isNotSafe;
+            isNotSafe = leftIsSafe && centerIsSafe && !rightIsSafe;
+            if (isNotSafe)
+                return isNotSafe;
+
+            return isNotSafe;
+        }
+
+        #endregion
+
+    }
+}

--- a/AdventOfCode2016Tests/AdventOfCode2016Tests.csproj
+++ b/AdventOfCode2016Tests/AdventOfCode2016Tests.csproj
@@ -41,6 +41,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Inputs\Day18\Day18Test1.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day18\Day18Test2.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Inputs\Day17\Day17Test3.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/AdventOfCode2016Tests/Day18.cs
+++ b/AdventOfCode2016Tests/Day18.cs
@@ -1,0 +1,41 @@
+using System.Drawing;
+
+namespace AdventOfCode2016Tests
+{
+    [TestClass]
+    public class Day18
+    {
+        [TestMethod]
+        [DeploymentItem("Inputs/Day18/Day18Test1.txt")]
+        public void Part1_OutputsCorrectSafeTileCountFile1_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day18("Day18Test1.txt", 3);
+            instance.FirstResult.Should().Be(6);
+        }
+        [TestMethod]
+        [DeploymentItem("Inputs/Day18/Day18Test2.txt")]
+        public void Part1_OutputsCorrectSafeTileCountFile2_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day18("Day18Test2.txt", 10);
+            instance.FirstResult.Should().Be(38);
+        }
+
+        [TestMethod]
+        [DeploymentItem("Inputs/Day18/Day18Test1.txt")]
+        public void Part2_OutputsCorrectSafeTileCountFile1_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day18("Day18Test1.txt", 3);
+            instance.SecondResult.Should().Be(600001);
+        }
+
+
+        [TestMethod]
+        [DeploymentItem("Inputs/Day18/Day18Test2.txt")]
+        public void Part2_OutputsCorrectSafeTileCountFile2_IsTrue()
+        {
+            var instance = new AdventOfCode2016.Problems.Day18("Day18Test2.txt", 10);
+            instance.SecondResult.Should().Be(1935478);
+        }
+
+    }
+}


### PR DESCRIPTION
Implemented solution for AoC 2016 Day 18

Part 1 and 2 use the same solution but with different row limits. We process each next row based on the values in the previous row, calculating the safety of each char within the string.

We then do a SelectMany to flatten the list, filter it to just the '.' chars and then select the count from the remaining elements.