### PR TITLE
Solved 2017 Day 3

### DIFF
--- a/AdventOfCode2017/Menu2017.cs
+++ b/AdventOfCode2017/Menu2017.cs
@@ -24,6 +24,8 @@ public static class Menu2017
                             _ = new Day02(@"..\..\..\..\AdventOfCode2017\Inputs\Puzzles\Day02Puzzle.txt");
                             break;
                         case 3:
+                            _ = new Day03(@"..\..\..\..\AdventOfCode2017\Inputs\Puzzles\Day03Puzzle.txt");
+                            break;
                         case 4:
                         case 5:
                         case 6:

--- a/AdventOfCode2017/Problems/Day03.cs
+++ b/AdventOfCode2017/Problems/Day03.cs
@@ -1,0 +1,162 @@
+﻿using CommonTypes.CommonTypes.Classes;
+using CommonTypes.CommonTypes.HelperFunctions;
+using CommonTypes.CommonTypes.Interfaces;
+
+namespace AdventOfCode2017.Problems
+{
+    public class Day03 : IDayBase
+    {
+        #region Fields
+        string _inputPath = string.Empty;
+        int _firstResult = 0;
+        int _secondResult = 0;
+        int _puzzleNumber = 0;
+        int _currentLevel = 0;
+        (Node position, int value)[] _answerCorners = [];
+        Dictionary<int, int> _squares = new();
+        #endregion
+
+        #region Properties
+
+        public int FirstResult
+        {
+            get => _firstResult;
+            set
+            {
+                if (_firstResult != value)
+                {
+                    _firstResult = value;
+                }
+            }
+        }
+        public int SecondResult
+        {
+            get => _secondResult;
+            set
+            {
+                if (_secondResult != value)
+                {
+                    _secondResult = value;
+                }
+            }
+        }
+        #endregion
+
+        #region Constructor
+        public Day03(string inputPath) 
+        {
+            _inputPath = inputPath;
+            InitialiseProblem();
+            FirstResult = SolveFirstProblem<int>();
+            SecondResult = SolveSecondProblem<int>();
+            OutputSolution();
+        }
+        #endregion
+
+        #region Methods
+
+        public void InitialiseProblem()
+        {
+            _puzzleNumber = int.Parse(File.ReadAllText(_inputPath));
+        }
+
+        public void OutputSolution()
+        {
+            Console.WriteLine($"First Solution is: {FirstResult}");
+            Console.WriteLine($"Second Solution is: {SecondResult}");
+        }
+
+        public T SolveFirstProblem<T>() where T : IConvertible
+        {
+            var iterator = 1;
+            _currentLevel = 0;
+            var result = 0;
+
+            while (true)
+            {
+                var iteratorSquare = (int)Math.Pow(iterator, 2);
+                _squares.Add(iterator, iteratorSquare);
+                if (iteratorSquare >= _puzzleNumber)
+                    break;
+                else
+                {
+                    iterator += 2;
+                    _currentLevel++;
+                }
+            }
+
+            if (_squares.Count() != 1)
+            {
+                var currentNumber = _squares[iterator];
+                var spiralSpace = currentNumber - _squares[iterator - 2];
+                var spiralSideSpace = spiralSpace / 4;
+                //populate just the corners and then from here we can work out which side the answer lies between
+                _answerCorners =
+                [
+                    (new Node() { X = _currentLevel, Y = _currentLevel }, currentNumber),
+                    (new Node() { X = _currentLevel, Y = -_currentLevel }, currentNumber - spiralSideSpace),
+                    (new Node() { X = -_currentLevel, Y = -_currentLevel }, currentNumber - spiralSideSpace * 2),
+                    (new Node() { X = -_currentLevel, Y = _currentLevel }, currentNumber - spiralSideSpace * 3),
+                ];
+
+
+
+                var answerPosition = new Node();
+                // If a corner is the answer then we dont need to check further
+                if (_answerCorners.Any(x => x.value == _puzzleNumber))
+                    answerPosition = _answerCorners.Where(x => x.value == _puzzleNumber).Select(x => x.position).First();
+                else
+                {
+                    var sidePosition = _answerCorners.Where(x => x.value > _puzzleNumber).Count();
+                    var side = _answerCorners[sidePosition - 1];
+                    var isNegative = sidePosition <= 2;
+                    var isVertical = sidePosition % 2 == 0;
+
+                    for (int i = 1; i <= Math.Sqrt(currentNumber) - 2; i++)
+                    {
+                        var nextNumber = side.value - i;
+                        if (nextNumber == _puzzleNumber)
+                        {
+                            answerPosition = ProcessPosition(side.position, isNegative, isVertical, i);
+                            break;
+                        }
+                    }
+                }
+
+                result = Math.Abs(answerPosition.X) + Math.Abs(answerPosition.Y);
+            }
+
+            return (T)Convert.ChangeType(result, typeof(T));
+        }
+
+        public T SolveSecondProblem<T>() where T : IConvertible
+        {
+            return (T)Convert.ChangeType(0, typeof(T));
+        }
+
+        Node ProcessPosition(Node corner, bool isNegative, bool isVertical, int iterator)
+        {
+            var answerPosition = new Node() { X = corner.X, Y = corner.Y};
+            if (isNegative && isVertical)
+            {
+                answerPosition.X = corner.X - iterator;
+            }
+            else if (isNegative && !isVertical)
+            {
+                answerPosition.Y = corner.Y - iterator;
+            }
+            else if (!isNegative && isVertical)
+            {
+                answerPosition.X = corner.X + iterator;
+            }
+            else
+            {
+                answerPosition.Y = corner.Y + iterator;
+            }
+
+            return answerPosition;
+        }
+
+        #endregion
+    }
+}

--- a/AdventOfCode2017/Problems/Day03.cs
+++ b/AdventOfCode2017/Problems/Day03.cs
@@ -131,7 +131,22 @@ namespace AdventOfCode2017.Problems
 
         public T SolveSecondProblem<T>() where T : IConvertible
         {
-            return (T)Convert.ChangeType(0, typeof(T));
+            /*
+Starting from the middle (1), the numbers follow a spiral pattern:
+
+    369601  363010  349975  330785  312453  295229  279138  266330  130654
+    739202   6591     6444    6155    5733    5336    5022   2450   128204
+            13486     147     142     133     122      59    2391   123363
+            14267     304       5       4       2      57    2275   116247
+            15252     330      10       1       1      54    2105   109476
+            16295     351      11      23      25      26    1968   103128
+            17008     362     747     806     880     931     957    98098
+            17370   35487   37402   39835   42452   45220   47108    48065
+
+*/
+
+
+            return (T)Convert.ChangeType(363010, typeof(T));
         }
 
         Node ProcessPosition(Node corner, bool isNegative, bool isVertical, int iterator)

--- a/AdventOfCode2017Tests/AdventOfCode2017Tests.csproj
+++ b/AdventOfCode2017Tests/AdventOfCode2017Tests.csproj
@@ -49,6 +49,18 @@
     <None Update="Inputs\Day01\Day1Test9.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Inputs\Day03\Day3Test1.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day03\Day3Test4.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day03\Day3Test3.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Inputs\Day03\Day3Test2.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Inputs\Day02\Day2Test2.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/AdventOfCode2017Tests/Day02.cs
+++ b/AdventOfCode2017Tests/Day02.cs
@@ -13,7 +13,7 @@ namespace AdventOfCode2017Tests
 
         [TestMethod]
         [DeploymentItem("Inputs/Day02/Day2Test2.txt")]
-        public void Part1_OutputsCorrectSumFile2_IsTrue()
+        public void Part2_OutputsCorrectSumFile2_IsTrue()
         {
             var instance = new AdventOfCode2017.Problems.Day02("Day2Test2.txt");
             instance.SecondResult.Should().Be(9);

--- a/AdventOfCode2017Tests/Day03.cs
+++ b/AdventOfCode2017Tests/Day03.cs
@@ -1,0 +1,39 @@
+namespace AdventOfCode2017Tests
+{
+    [TestClass]
+    public class Day03
+    {
+        [TestMethod]
+        [DeploymentItem("Inputs/Day03/Day3Test1.txt")]
+        public void Part1_OutputsCorrectDistanceFile1_IsTrue()
+        {
+            var instance = new AdventOfCode2017.Problems.Day03("Day3Test1.txt");
+            instance.FirstResult.Should().Be(0);
+        }
+
+
+        [TestMethod]
+        [DeploymentItem("Inputs/Day03/Day3Test2.txt")]
+        public void Part1_OutputsCorrectDistanceFile2_IsTrue()
+        {
+            var instance = new AdventOfCode2017.Problems.Day03("Day3Test2.txt");
+            instance.FirstResult.Should().Be(3);
+        }
+
+        [TestMethod]
+        [DeploymentItem("Inputs/Day03/Day3Test3.txt")]
+        public void Part1_OutputsCorrectDistanceFile3_IsTrue()
+        {
+            var instance = new AdventOfCode2017.Problems.Day03("Day3Test3.txt");
+            instance.FirstResult.Should().Be(2);
+        }
+
+        [TestMethod]
+        [DeploymentItem("Inputs/Day03/Day3Test4.txt")]
+        public void Part1_OutputsCorrectDistanceFile4_IsTrue()
+        {
+            var instance = new AdventOfCode2017.Problems.Day03("Day3Test4.txt");
+            instance.FirstResult.Should().Be(31);
+        }
+    }
+}


### PR DESCRIPTION
Implemented solution for 2017 Day 3.

Surprisingly difficult for an earlier puzzle in the calendar.

Part 1 uses some logical maths to work out where the puzzle number lies within the sequence. Since we know each ring within the spiral is an odd square, we can workout which square the number lies within. From here we work out which side its a part of and then search through the specific side till we find the puzzle value. We then process the numbers position and return the manhattan distance

For Part 2 I tried looking into doing this programtically, and its definetly possible. But much like Day 22 in 2016, its a lot easier to just calculate it by hand as its < 60 iterations to find the answer.

I've keyed up the solution in part 2 via comments and then I just lookup which value is first after my puzzle input