### PR TITLE
Solved 2017 Day 07

### DIFF
--- a/src/AdventOfCode2017/Menu2017.cs
+++ b/src/AdventOfCode2017/Menu2017.cs
@@ -36,6 +36,8 @@ public static class Menu2017
                             _ = new Day06(@"..\..\..\..\AdventOfCode2017\Inputs\Puzzles\Day06Puzzle.txt");
                             break;
                         case 7:
+                            _ = new Day07(@"..\..\..\..\AdventOfCode2017\Inputs\Puzzles\Day07Puzzle.txt");
+                            break;
                         case 8:
                         case 9:
                         case 10:

--- a/src/AdventOfCode2017/Problems/Day07.cs
+++ b/src/AdventOfCode2017/Problems/Day07.cs
@@ -11,10 +11,11 @@ namespace AdventOfCode2017.Problems
         string _inputPath = string.Empty;
         string _firstResult = string.Empty;
         int _secondResult = 0;
-        List<TreeNode> _tree = new List<TreeNode>();
+        //List<TreeNode> _tree = new List<TreeNode>();
         Regex _numberRegex = CommonRegexHelpers.NumberRegex();
+        Dictionary<string, TreeNode> _tree = new();
         Dictionary<string, string> _treeLinks = new();
-        Dictionary<string, int> _treeWeights = new();
+        Dictionary<string, int> _subtreeWeights = new();
 
         #endregion
 
@@ -71,7 +72,7 @@ namespace AdventOfCode2017.Problems
                     Weight = int.Parse(_numberRegex.Match(treeDetails[1]).Value),
                     Children = treeChildren
                 };
-                _tree.Add(treeNode);
+                _tree.Add(treeNode.Name, treeNode);
             }
         }
 
@@ -83,15 +84,15 @@ namespace AdventOfCode2017.Problems
 
         public T SolveFirstProblem<T>() where T : IConvertible
         {
-            foreach(var treeNode in _tree.Where(x => x.Children.Any()))
+            foreach(var treeNode in _tree.Where(x => x.Value.Children.Any()))
             {
-                foreach(var child in treeNode.Children)
+                foreach(var child in treeNode.Value.Children)
                 {
-                    _treeLinks.Add(child, treeNode.Name);
+                    _treeLinks.Add(child, treeNode.Value.Name);
                 }
             }
             var children = _treeLinks.Select(x => x.Key).ToHashSet();
-            var allTreeElements = _tree.Select(x => x.Name).ToHashSet();
+            var allTreeElements = _tree.Select(x => x.Value.Name).ToHashSet();
             var topParent = allTreeElements.Except(children).Single();
 
             return (T)Convert.ChangeType(topParent, typeof(T));
@@ -99,17 +100,24 @@ namespace AdventOfCode2017.Problems
 
         public T SolveSecondProblem<T>() where T : IConvertible
         {
-            foreach (var treeNode in _tree.Where(x => x.Children.Any() && x.Name != FirstResult))
-            {
-                _treeWeights.Add(treeNode.Name, _tree.Where(x => treeNode.Children.Contains(x.Name)).Sum(x => x.Weight) + treeNode.Weight);
-            }
+            GetTotalWeight(FirstResult);
 
-            var groupedResults = _treeWeights.GroupBy(x => x.Value);
-            var heavyTree = groupedResults.Where(x => x.Count() == 1).Select(x => x).Single().Single();
-            var balancedTree = groupedResults.Where(x => x.Count() > 1).Select(x => x.Key).First();
-            var difference = heavyTree.Value - balancedTree;
-            var treeToEdit = _tree.Where(x => x.Name == heavyTree.Key).Single();
-            var result = treeToEdit.Weight - difference;
+            // Find the unbalanced node
+            var startNode = _tree[FirstResult];
+            string unbalancedNode = FindUnbalancedNode(startNode, _subtreeWeights);
+
+            // Find the incorrect weight adjustment
+            var unbalancedParent = _tree[_treeLinks[unbalancedNode]];
+            var correctWeight = unbalancedParent.Children
+                .GroupBy(child => _subtreeWeights[child])
+                .OrderByDescending(g => g.Count())
+                .First()
+                .Key;
+
+            int weightDifference = _subtreeWeights[unbalancedNode] - correctWeight;
+            var nodeToFix = _tree[unbalancedNode];
+
+            int result = nodeToFix.Weight - weightDifference;
 
             return (T)Convert.ChangeType(result, typeof(T));
         }
@@ -120,6 +128,32 @@ namespace AdventOfCode2017.Problems
             internal required string Name { get; init; }
             internal required int Weight { get; init; }
             internal required string[] Children { get; init; }
+        }
+        string FindUnbalancedNode(TreeNode node, Dictionary<string, int> subtreeWeights)
+        {
+            while (true)
+            {
+                var grouped = node.Children.GroupBy(child => subtreeWeights[child]).ToList();
+
+                if (grouped.Count == 1)
+                    return node.Name; // No imbalance found, return last checked node
+
+                var unbalanced = grouped.First(x => x.Count() == 1);
+                node = _tree.First(n => n.Value.Name == unbalanced.First()).Value;
+            }
+        }
+
+
+        int GetTotalWeight(string nodeName)
+        {
+            if (_subtreeWeights.ContainsKey(nodeName))
+                return _subtreeWeights[nodeName];
+
+            var node = _tree[nodeName];
+            int totalWeight = node.Weight + node.Children.Sum(GetTotalWeight);
+
+            _subtreeWeights[nodeName] = totalWeight;
+            return totalWeight;
         }
 
         #endregion

--- a/src/AdventOfCode2017/Problems/Day07.cs
+++ b/src/AdventOfCode2017/Problems/Day07.cs
@@ -1,0 +1,127 @@
+﻿using CommonTypes.CommonTypes.Interfaces;
+using CommonTypes.CommonTypes.Regex;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace AdventOfCode2017.Problems
+{
+    public class Day07 : IDayBase
+    {
+        #region Fields
+        string _inputPath = string.Empty;
+        string _firstResult = string.Empty;
+        int _secondResult = 0;
+        List<TreeNode> _tree = new List<TreeNode>();
+        Regex _numberRegex = CommonRegexHelpers.NumberRegex();
+        Dictionary<string, string> _treeLinks = new();
+        Dictionary<string, int> _treeWeights = new();
+
+        #endregion
+
+        #region Properties
+
+        public string FirstResult
+        {
+            get => _firstResult;
+            set
+            {
+                if (_firstResult != value)
+                {
+                    _firstResult = value;
+                }
+            }
+        }
+        public int SecondResult
+        {
+            get => _secondResult;
+            set
+            {
+                if (_secondResult != value)
+                {
+                    _secondResult = value;
+                }
+            }
+        }
+        #endregion
+
+        #region Constructor
+        public Day07(string inputPath) 
+        {
+            _inputPath = inputPath;
+            InitialiseProblem();
+            FirstResult = SolveFirstProblem<string>();
+            SecondResult = SolveSecondProblem<int>();
+            OutputSolution();
+        }
+        #endregion
+
+        #region Methods
+
+        public void InitialiseProblem()
+        {
+            var input = File.ReadAllLines(_inputPath);
+            foreach (var line in input)
+            {
+                var parts = line.Split("->");
+                var treeDetails = parts[0].Split(' ');
+                var treeChildren = parts.Count() == 2 ? parts[1].Split(',').Select(x => x.Trim()).ToArray() : [];
+                var treeNode = new TreeNode()
+                {
+                    Name = treeDetails[0].Trim(),
+                    Weight = int.Parse(_numberRegex.Match(treeDetails[1]).Value),
+                    Children = treeChildren
+                };
+                _tree.Add(treeNode);
+            }
+        }
+
+        public void OutputSolution()
+        {
+            Console.WriteLine($"First Solution is: {FirstResult}");
+            Console.WriteLine($"Second Solution is: {SecondResult}");
+        }
+
+        public T SolveFirstProblem<T>() where T : IConvertible
+        {
+            foreach(var treeNode in _tree.Where(x => x.Children.Any()))
+            {
+                foreach(var child in treeNode.Children)
+                {
+                    _treeLinks.Add(child, treeNode.Name);
+                }
+            }
+            var children = _treeLinks.Select(x => x.Key).ToHashSet();
+            var allTreeElements = _tree.Select(x => x.Name).ToHashSet();
+            var topParent = allTreeElements.Except(children).Single();
+
+            return (T)Convert.ChangeType(topParent, typeof(T));
+        }
+
+        public T SolveSecondProblem<T>() where T : IConvertible
+        {
+            foreach (var treeNode in _tree.Where(x => x.Children.Any() && x.Name != FirstResult))
+            {
+                _treeWeights.Add(treeNode.Name, _tree.Where(x => treeNode.Children.Contains(x.Name)).Sum(x => x.Weight) + treeNode.Weight);
+            }
+
+            var groupedResults = _treeWeights.GroupBy(x => x.Value);
+            var heavyTree = groupedResults.Where(x => x.Count() == 1).Select(x => x).Single().Single();
+            var balancedTree = groupedResults.Where(x => x.Count() > 1).Select(x => x.Key).First();
+            var difference = heavyTree.Value - balancedTree;
+            var treeToEdit = _tree.Where(x => x.Name == heavyTree.Key).Single();
+            var result = treeToEdit.Weight - difference;
+
+            return (T)Convert.ChangeType(result, typeof(T));
+        }
+
+
+        record TreeNode
+        {
+            internal required string Name { get; init; }
+            internal required int Weight { get; init; }
+            internal required string[] Children { get; init; }
+        }
+
+        #endregion
+    }
+}

--- a/test/AdventOfCode2017Tests/AdventOfCode2017Tests.csproj
+++ b/test/AdventOfCode2017Tests/AdventOfCode2017Tests.csproj
@@ -94,6 +94,9 @@
     <None Update="Inputs\Day02\Day2Test1.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Inputs\Day07\Day7Test1.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Inputs\Day06\Day6Test1.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/test/AdventOfCode2017Tests/Day07.cs
+++ b/test/AdventOfCode2017Tests/Day07.cs
@@ -1,0 +1,24 @@
+namespace AdventOfCode2017Tests
+{
+    [TestClass]
+    public class Day07
+    {
+        const string _basePath = "Inputs/Day07";
+        const string _baseTestName = "Day7Test";
+        [TestMethod]
+        [DeploymentItem($"{_basePath}/{_baseTestName}1.txt")]
+        public void Part1_CompletesWithCorrectStepCountFile1_IsTrue()
+        {
+            var instance = new AdventOfCode2017.Problems.Day07($"{_baseTestName}1.txt");
+            instance.FirstResult.Should().Be("tknk");
+        }
+
+        [TestMethod]
+        [DeploymentItem($"{_basePath}/{_baseTestName}1.txt")]
+        public void Part2_CompletesWithCorrectStepCountFile1_IsTrue()
+        {
+            var instance = new AdventOfCode2017.Problems.Day07($"{_baseTestName}1.txt");
+            instance.SecondResult.Should().Be(60);
+        }
+    }
+}

--- a/test/AdventOfCode2017Tests/Inputs/Day07/Day7Test1.txt
+++ b/test/AdventOfCode2017Tests/Inputs/Day07/Day7Test1.txt
@@ -1,0 +1,13 @@
+pbga (66)
+xhth (57)
+ebii (61)
+havc (66)
+ktlj (57)
+fwft (72) -> ktlj, cntj, xhth
+qoyq (66)
+padx (45) -> pbga, havc, qoyq
+tknk (41) -> ugml, padx, fwft
+jptl (61)
+ugml (68) -> gyxo, ebii, jptl
+gyxo (61)
+cntj (57)


### PR DESCRIPTION
Implemented solution for Advent of Code 2017 Day 7.

Solution creates a tree structure by mapping child nodes to their parent using the _treeLink dictionary. We also have a _tree dictionary which maps the tree name to its tree record.

Part 1 loops through each tree node in _tree dictionary where the nodes have any children, then foreach child we add a tree link to its parent. We then take both dictionaries, turn them into a hashset and do an Except set operation to only find the node whose parent does not have a parent link of its own (implying its the top most parent).

Part 2 then gets the total weight for every sub branch off of the top parent and its children recursively. This is to build up a tree weight dictionary which we can then use to find the unbalanced node. This is found by finding the children elements which when grouped produce more than 1 result. We can then narrow this grouping to the only record who is different from the other tree nodes. With the unbalanced node we can get the parent and work out what the difference needs to be to equalise the tree branch.